### PR TITLE
fix(deps): unpin transformers to >=5.5.0,<6 (two high-severity CVEs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ numpy = ">=1.24.0"
 # personal agent
 
 # from personal_agent
-transformers = ">=4.40.0,<4.57"
+transformers = ">=5.5.0,<6"
 sentence-transformers = "^5.2.0"
 safetensors = ">=0.5.0"
 


### PR DESCRIPTION
## Why

`transformers>=4.40.0,<4.57` held the stack at **4.56.2**, which carries two open high-severity advisories:

| Advisory | Vulnerable | Fixed |
|---|---|---|
| Remote code execution | `< 5.3.0` | 5.3.0 |
| Arbitrary code execution — LightGlue model-loading path | `< 5.5.0` | 5.5.0 |

Surfaced as a Dependabot alert on **proteusPy**, which pulls transformers transitively via `doc-kg` and `pycode-kg`.

The cap was introduced with no recorded rationale, bundled into an unrelated commit. It also no longer matched anything real — `doc-kg` 0.12.3 had already shipped on transformers 5.6.2, and the `<4.57` value was aligned to a `personal_agent` constraint that has since moved to `^4.57.6`.

Our actual transformers surface is two calls — `set_verbosity_error()` and `disable_progress_bar()`. No modeling classes, no tokenizer API, no `huggingface_hub` calls. Everything else goes through `sentence-transformers`, which already allows `<6.0.0`.

## Verification

Tested against transformers **5.14.1** with the rest of the stack unchanged (torch 2.13.0, sentence-transformers 5.6.1):

- **Embeddings bitwise identical** on `bge-small-en-v1.5` (384d), `bge-large-en-v1.5` (1024d) and `nomic-embed-text-v1.5` (768d, the `trust_remote_code` path) — including empty strings, whitespace-only, 3k chars, unicode/emoji and CRLF inputs
- **Full index rebuild → byte-identical `vectors.sqlite`** (2847-vector corpus)
- **Queries against an index built on 4.56.2** return identical rankings and scores under 5.14.1
- **Suites pass on both 4.56.2 and 5.14.1**: doc_kg 418, KG_utils 532, pycode_kg 403

**No re-index is required.**

## Notes

- `huggingface-hub` moves 0.36.2 → 1.x (transformers 5 requires `>=1.5.0,<2.0`). Nothing in the KG stack caps it.
- `typer` arrives as a new transitive dep of transformers 5; it requires only `rich>=13.8.0`, so existing `rich<15` caps still resolve.
- Locks are **not** updated here — that belongs to the release train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## ⚠️ Blocked: lock pending doc-kg / pycode-kg releases

`poetry lock` fails here with:

```
Because doc-kg (0.18.2) depends on transformers (>=4.40.0,<4.57)
 and no versions of doc-kg match >0.18.2, doc-kg (>=0.18.2) requires transformers (>=4.40.0,<4.57).
So, because kg-rag depends on both transformers (>=5.5.0,<6) and doc-kg (>=0.18.2), version solving failed.
```

Unlike the other repos, kgrag **keeps** its `doc-kg` / `pycode-kg` dependencies on purpose — the adapters construct real `DocKG` / `PyCodeKG` objects, and the test group needs them to exercise the real classes rather than mocks. So this PR simply waits.

kgrag is a leaf — nothing depends on it — so it locks last, once doc-kg and pycode-kg are released. At that point it also wants `kgmodule-utils>=0.9.0`.
