### PR TITLE
fix(deps): pin mcp<2 — kgrag-mcp cannot start against mcp 2.x

### DIFF
--- a/src/kg_rag/model_coordinator.py
+++ b/src/kg_rag/model_coordinator.py
@@ -403,10 +403,13 @@ class ModelCoordinator:
             ) from e
 
         local_path.mkdir(parents=True, exist_ok=True)
+        # `local_dir_use_symlinks` was dropped in huggingface_hub 1.x — passing it
+        # only raises a deprecation warning and is otherwise ignored (downloads to
+        # a local dir no longer symlink into the cache), so it is removed rather
+        # than carried. Behaviour is unchanged.
         snapshot_download(
             repo_id=repo_id,
             local_dir=str(local_path),
-            local_dir_use_symlinks=False,
             ignore_patterns=[
                 "onnx/*",
                 "onnx_quantized/*",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,75 @@
+"""tests/test_mcp_server.py
+
+Regression tests for kg_rag.mcp_server against the installed ``mcp`` release.
+
+KGRAG uses the **low-level** MCP API — ``Server`` plus the
+``@server.list_tools()`` / ``@server.call_tool()`` decorators. mcp 2.0 kept the
+``Server`` class importable but removed those decorators, so the break shows up
+as an ``AttributeError`` when :func:`_make_server` runs rather than at import
+time. A plain "does the module import" test would pass while ``kgrag-mcp``
+remained completely broken, so these tests build the server for real.
+
+That distinction matters across the fleet: sibling packages using ``FastMCP``
+fail at *import* under mcp 2.0 (the ``mcp.server.fastmcp`` module was unbundled
+into the standalone ``fastmcp`` package), while KGRAG fails at *call* time.
+`pyproject.toml` pins ``mcp<2`` for this reason.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+
+def test_server_module_imports():
+    """The module must import cleanly against the installed mcp release."""
+    importlib.import_module("kg_rag.mcp_server")
+
+
+def test_lowlevel_decorator_api_exists():
+    """``Server`` must still expose the decorators mcp 2.0 removed.
+
+    Asserted directly so a future incompatibility names the missing API instead
+    of surfacing as an opaque AttributeError from inside _make_server().
+    """
+    from mcp.server import Server
+
+    server = Server("probe")
+    for attr in ("list_tools", "call_tool"):
+        assert hasattr(server, attr), (
+            f"mcp.server.Server has no {attr!r} — the low-level decorator API "
+            "was removed in mcp 2.0; kg_rag.mcp_server cannot register handlers"
+        )
+
+
+def test_make_server_registers_handlers(tmp_path: Path):
+    """Building the server must run both decorators and register handlers.
+
+    This is the test that actually catches mcp 2.0: the decorators execute here,
+    not at import.
+    """
+    mcp_server = importlib.import_module("kg_rag.mcp_server")
+    server = mcp_server._make_server(tmp_path / "registry.sqlite")
+    assert server.request_handlers, "no request handlers registered"
+
+
+def test_entry_point_target_exists():
+    """``kgrag-mcp`` resolves to kg_rag.mcp_server:main."""
+    mcp_server = importlib.import_module("kg_rag.mcp_server")
+    assert callable(mcp_server.main)
+
+
+def test_tools_are_registered(tmp_path: Path):
+    """The advertised tool list survives registration and is non-empty."""
+    import asyncio
+
+    from mcp.types import ListToolsRequest
+
+    mcp_server = importlib.import_module("kg_rag.mcp_server")
+    server = mcp_server._make_server(tmp_path / "registry.sqlite")
+
+    handler = server.request_handlers[ListToolsRequest]
+    result = asyncio.run(handler(ListToolsRequest(method="tools/list")))
+    names = {t.name for t in result.root.tools}
+    assert names, "no tools registered"
+    assert "kgrag_stats" in names


### PR DESCRIPTION
Third repo in the fleet-wide `mcp<2` sweep, after `pycode-kg 0.21.1` and `agent-kg 0.8.1` (both already published with the pin).

**KGRAG is the most consequential of the three** — as the federation entry point, `kgrag-mcp` failing takes the whole cross-KG surface down with it.

---

## The break

mcp 2.0 removed the low-level `Server` decorator API that `kg_rag.mcp_server` is built on. Verified against a real mcp 2.0 install rather than inferred:

```pycon
>>> from mcp.server import Server        # still imports fine
>>> Server("probe").list_tools
AttributeError: 'Server' object has no attribute 'list_tools'
```

`Server` itself still imports, so nothing fails until `_make_server()` runs — at which point `@server.list_tools()` raises and **no handler is ever registered**. The previous unbounded `mcp>=1.0.0` meant a clean install resolved 2.0 and produced a `kgrag-mcp` that could not start. Developers never saw it: a pinned lock file keeps working, so the failure is visible only to someone installing fresh from PyPI.

## The failure mode differs across the fleet

This is why the pin can't be copied blindly between repos:

| API | Under mcp 2.0 | Fails at | Repos |
|---|---|---|---|
| `mcp.server.fastmcp.FastMCP` | module unbundled into standalone `fastmcp` | **import** | pycode_kg, doc_kg, memory_kg, Metabo_kg, diary_kg |
| `mcp.server.Server` decorators | class survives, decorators removed | **call** | **kgrag** |

## Tests

`tests/test_mcp_server.py` — 5 tests. KGRAG builds its server inside `_make_server()` rather than at module scope, so the import-only shape used in the sibling repos **would pass while `kgrag-mcp` stayed completely broken**. These build the server for real and assert handlers register.

One test asserts the `Server` decorator API exists on its own, so a future break names the missing API instead of surfacing as an opaque `AttributeError` from inside `_make_server()`.

Confirmed genuinely red under mcp 2.0 — `Server.list_tools` and `Server.call_tool` both report MISSING.

## Also in this PR

**`local_dir_use_symlinks` removed from `snapshot_download`** (separate commit). huggingface_hub 1.x dropped the parameter; it is not a hard error — a validator intercepts it and warns *"deprecated and ignored"* — so downloads still worked, but the argument did nothing and `ty` flagged the call as matching no overload. Removing it is behaviour-preserving and clears the last `ty` diagnostic in `src/`.

This commit also carries two dependency bumps that were already in the working tree when this work started — `transformers` to `>=5.5.0,<6` and `ftree-kg` to `>=0.9.0` — since they sit in the same file and could not be staged separately.

## Version

**No bump.** `0.11.0` is already staged across `pyproject.toml`, `src/kg_rag/__init__.py`, `CITATION.cff`, and the README badge / APA citation / BibTeX, and has not been tagged or published (PyPI is on `0.10.0`). This folds into that pending release, so the changelog entry lands under `[0.11.0]` rather than creating a new section.

Version strings verified coherent across all five locations.

## Verification

| Check | Result |
|---|---|
| `pytest` | **486 passed** |
| `ruff check` / `format` | clean / 76 files |
| `ty check src/` | **clean** (was 1 diagnostic) |
| `poetry check --lock` | valid; `mcp` resolves to 1.27.2 |
| Pre-commit hooks | all green |

## Still outstanding fleet-wide

`doc-kg 0.19.0` and `memory-kg 0.6.0` remain published with unbounded `mcp>=1.0.0`; both use `FastMCP` and so fail at import under mcp 2.0. `Metabo_kg` and `diary_kg` need the pin before their next publish — `Metabo_kg` imports FastMCP lazily inside a function, so it fails at call time, which is harder to diagnose rather than safer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
