### PR TITLE
TODO: file doc-kg/diary-kg lancedb hard-requirement from corpus_pepys

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -64,3 +64,11 @@ for every KG kind.
   `.pycodekg/`.
 - **KG_utils 0.7.0** plans to split `lancedb` out of the `[semantic]` extra so the
   package stops installing transitively.
+- **doc-kg / diary-kg still hard-require `lancedb>=0.29.0`** (checked 2026-07-30
+  at doc-kg 0.19.1 / diary-kg 0.93.4, filed from `corpus_pepys`). The
+  kgmodule-utils side is done — 0.9.0 gates lancedb behind `[semantic]` — and
+  corpus_pepys no longer imports lancedb anywhere (worker is sqlite-vec only,
+  LanceDB fallback removed), but the package still lands in every worker image
+  transitively. Full retirement needs doc-kg/diary-kg releases that demote
+  lancedb to an optional extra; also cosmetic: `diarykg build` still prints a
+  "LanceDB :" path label while writing `vectors.sqlite`.


### PR DESCRIPTION
## Summary

Docs-only: adds a coordination note to `TODO.md` under the LanceDB-retirement section, filed from the corpus_pepys pin update (flux-frontiers/corpus_pepys — "Update KG pins to fleet latest and port worker to sqlite-vec").

What it records, verified against published PyPI metadata on 2026-07-30:
- **doc-kg 0.19.1 and diary-kg 0.93.4 still hard-require `lancedb>=0.29.0`**, so the package lands in every worker image transitively even where nothing imports it
- The kgmodule-utils side is done — 0.9.0 gates lancedb behind the `[semantic]` extra
- corpus_pepys is now sqlite-vec only (worker ported, LanceDB fallback removed, zero lancedb imports)
- Full retirement needs upstream doc-kg/diary-kg releases demoting lancedb to an optional extra; also cosmetic: `diarykg build` still prints a "LanceDB :" path label while writing `vectors.sqlite`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaBVS1zDC7QQumo8UyAWYT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaBVS1zDC7QQumo8UyAWYT)_