### PR TITLE
Fix the KG liveness probe, correct the release title, and reconcile the fleet migration audit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,6 @@ jobs:
             gh release upload "$TAG" dist/* --clobber
           else
             gh release create "$TAG" dist/* \
-              --title "CodeKG $TAG" \
+              --title "KGRAG $TAG" \
               --notes-file release-notes.md
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kgrag health` probed every code/doc/memory KG with a broken command**
+  (`src/kg_rag/cli/cmd_health.py`) — three independent defects, all of which
+  made `_probe_kg` report a false failure (`stale_lancedb_probe`) on healthy
+  KGs. Verified against the installed CLIs (pycode-kg 0.21.2, doc-kg 0.19.1):
+  - **`-k 1` is not a valid option.** These CLIs declare only the long `--k`,
+    so every probe died on `Error: No such option '-k'` before touching an
+    index. This affected code, doc *and* memory probes regardless of migration
+    state.
+  - **`codekg` is not a binary.** pycode-kg ships `pycodekg` (renamed at 0.14);
+    the code probe and the code build-fix command both invoked `codekg`, so
+    they failed with "command not found". `cmd_audit.py` already used the
+    correct name — `cmd_health.py` was missed in the rename.
+  - **`--lancedb` with an empty value swallowed the next token.** The template
+    interpolated `entry.lancedb_path or ""`, and an empty value collapses under
+    `shlex.split`, leaving `--lancedb` to consume `-k`. Migrated KGs (which
+    record `vectors_path`, not `lancedb_path`) hit this every time; pycode-kg
+    ≥0.20 has no `--lancedb` option at all.
+
+  The probe now selects the flag from what the registry actually records —
+  `--vectors` for code, `--vectors-path`/`--lancedb` for the doc family — omits
+  it entirely when no store is recorded (each CLI has its own default layout,
+  and doc-kg's `--vector-backend auto` self-detects), shell-quotes paths, and
+  skips KGs with no graph. New tests in `tests/test_cmd_health.py` assert the
+  constructed argv: the existing probe tests all patched `_probe_kg`, so none
+  of them ever exercised a template, which is how this went unnoticed. One
+  pre-existing test asserted the `codekg` name and was corrected.
+
+- **`release.yml` titled GitHub releases "CodeKG"** — `gh release create
+  --title "CodeKG $TAG"` was a copy-paste from the code-kg repo, so every
+  published KGRAG release carried the wrong product name (v0.11.0 is titled
+  "CodeKG v0.11.0" on GitHub and needs a manual retitle).
+
+### Changed
+
+- **`TODO.md` corrections** — the kgmodule-utils note cited 0.7.0 as the
+  version "planning" to split `lancedb` out of `[semantic]`; 0.7.0 shipped long
+  ago and 0.9.0 is current, where `lancedb>=0.19.0` is *still* in `[semantic]`.
+  Also records that `gutenberg_kg` is migrated, which invalidates the
+  237-gutenberg row of the 2026-07-26 audit table (now flagged stale).
+
 ## [0.11.0] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ≥0.20 has no `--lancedb` option at all.
 
   The probe now selects the flag from what the registry actually records —
-  `--vectors` for code, `--vectors-path`/`--lancedb` for the doc family — omits
+  `--vectors` for code, `--vectors-path`/`--lancedb` for the doc family, and
+  `--lancedb` only for memory (memory-kg 0.6.2 has no sqlite-vec support at all,
+  so a converted memory KG cannot be probed — the failure there is real signal
+  rather than a malformed command) — omits
   it entirely when no store is recorded (each CLI has its own default layout,
   and doc-kg's `--vector-backend auto` self-detects), shell-quotes paths, and
   skips KGs with no graph. New tests in `tests/test_cmd_health.py` assert the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ago and 0.9.0 is current, where `lancedb>=0.19.0` is *still* in `[semantic]`.
   Also records that `gutenberg_kg` is migrated, which invalidates the
   237-gutenberg row of the 2026-07-26 audit table (now flagged stale).
+- **`TODO.md` fleet audit reconciled against `pycode_kg`'s
+  `MIGRATION-sqlite-vec.md`** — that document is the plan of record (phases,
+  per-repo effort, reference-implementation checklist) and `TODO.md` now defers
+  to it. It independently found the same `cmd_health.py` probe bug fixed above.
+  One of our findings was **wrong and is corrected**: diary-kg was called a
+  "dead dependency" droppable in a one-line release, on the basis that its
+  published wheel has zero `import lancedb`. It delegates to `dockg build` but
+  still passes `--lancedb` paths to that subprocess and plumbs
+  `self._lancedb_dir` throughout; the plan counts 30 source refs and sizes it as
+  a real Phase-1 port. A wheel-level grep cannot see CLI strings, prose, tests
+  or docs — the plan's repo-level counts supersede ours.
 
 ## [0.11.0] - 2026-07-29
 

--- a/TODO.md
+++ b/TODO.md
@@ -26,6 +26,9 @@ column and an in-place `_migrate()` step). All five suggested steps landed:
 holding **~2.0 GB** on disk. It is not gone — the schema work above only stopped
 kgrag *recording* it for new code KGs.
 
+> **Stale as of 2026-07-30** — the gutenberg corpora have since been migrated
+> (see Remaining coordination). Re-run the audit for real numbers.
+
 | Status | KGs | Note |
 |---|---|---|
 | `unmigrated` | 242 | 237 gutenberg, 3 doc, 2 code |
@@ -62,13 +65,30 @@ for every KG kind.
   Re-run `kgrag register <name> code <repo>` (or `kgrag scan --auto-register`) to
   record the real path — required for any repo whose vectors live outside
   `.pycodekg/`.
-- **KG_utils 0.7.0** plans to split `lancedb` out of the `[semantic]` extra so the
-  package stops installing transitively.
+- **kgmodule-utils has *not* split `lancedb` out of `[semantic]` yet** — corrected
+  2026-07-30. The old note here said "KG_utils 0.7.0 plans to…"; 0.7.0 shipped
+  long ago and **0.9.0 is the current release**, where `lancedb>=0.19.0` is still
+  an `[semantic]` requirement (alongside `sqlite-vec==0.1.9`, which 0.9.0 added
+  to both `[semantic]` and a standalone `[sqlite-vec]` extra). So `[semantic]`
+  still drags lancedb in; only installs that *avoid* `[semantic]` escape it.
+  kgrag itself is safe on this axis — it depends on bare `kgmodule-utils>=0.8.0`
+  with no extras — as is corpus_pepys, which installs
+  `[synthesis,sqlite-vec]`. The work item is unchanged, just not done: drop
+  `lancedb` from `[semantic]` in a future kgmodule-utils release.
 - **doc-kg / diary-kg still hard-require `lancedb>=0.29.0`** (checked 2026-07-30
-  at doc-kg 0.19.1 / diary-kg 0.93.4, filed from `corpus_pepys`). The
-  kgmodule-utils side is done — 0.9.0 gates lancedb behind `[semantic]` — and
-  corpus_pepys no longer imports lancedb anywhere (worker is sqlite-vec only,
-  LanceDB fallback removed), but the package still lands in every worker image
-  transitively. Full retirement needs doc-kg/diary-kg releases that demote
-  lancedb to an optional extra; also cosmetic: `diarykg build` still prints a
-  "LanceDB :" path label while writing `vectors.sqlite`.
+  at doc-kg 0.19.1 / diary-kg 0.93.4, filed from `corpus_pepys`). This is the
+  binding constraint: unlike the kgmodule-utils case above, it is an
+  unconditional dependency, so lancedb lands in every worker image no matter
+  which extras are selected. corpus_pepys no longer *imports* lancedb anywhere
+  (worker is sqlite-vec only, LanceDB fallback removed, merged as
+  corpus_pepys#1), but the package is still installed. Full retirement needs
+  doc-kg/diary-kg releases that demote lancedb to an optional extra; also
+  cosmetic: `diarykg build` still prints a "LanceDB :" path label while writing
+  `vectors.sqlite`.
+- **`gutenberg_kg` is migrated** — reported by the maintainer 2026-07-30 (done
+  outside this repo, so unverified here). Its pins are already
+  `kgmodule-utils[synthesis,sqlite-vec]>=0.8.0` / `doc-kg>=0.18.1` on `main`.
+  This invalidates the largest row of the audit table above (237 gutenberg
+  corpora counted as `unmigrated` on 2026-07-26) — **re-run `kgrag
+  audit-lancedb` for current numbers before treating that table as fleet
+  state.**

--- a/TODO.md
+++ b/TODO.md
@@ -58,42 +58,85 @@ for every KG kind.
 
 ### Fleet code-migration audit — 2026-07-30
 
-Measured against the **published packages** (installed from PyPI and grepped for
-real code paths, not just declared deps). This is about *code*, not on-disk
-vector artifacts — artifacts are regenerable, stale code is not.
+> **The plan of record is `pycode_kg/MIGRATION-sqlite-vec.md`** (dated
+> 2026-07-28) — phases, per-repo effort sizing, the reference implementation
+> checklist, and eleven hard-won learnings. **Read it before migrating anything;
+> this section only records what a package-level audit adds on top of it.**
+> Its recommended order: `diary_kg` → `Metabo_kg` → `memory_kg` → `doc_kg`,
+> with **`kgrag` last** (`agent_kg` since completed in PR #9).
+
+The table below measures the **published packages** (installed from PyPI,
+grepped for real code paths). That is a *narrower* lens than the plan's
+`grep -rn -i lancedb src/` over repo checkouts, and the difference matters —
+see the diary-kg correction below.
 
 | Package | Version | `lancedb` dep | imports `lancedb` | sqlite-vec aware | Verdict |
 |---|---|---|---|---|---|
-| `pycode-kg` | 0.21.2 | none | 0 files | yes | ✅ migrated |
-| `ftree-kg` | 0.9.0 | none | 0 files | yes | ✅ migrated |
-| `agent-kg` | 0.8.2 | none | 0 files | yes | ✅ migrated |
+| `pycode-kg` | 0.21.2 | none | 0 files | yes | ✅ migrated (reference impl) |
+| `ftree-kg` | 0.9.0 | none | 0 files | yes | ✅ migrated — v0.9.0 |
+| `agent-kg` | 0.8.2 | none | 0 files | yes | ✅ migrated — PR #9 |
 | `tscode-kg` | 0.2.0 | none | 0 files | yes | ✅ migrated |
 | `kgmodule-utils` | 0.9.0 | `[semantic]` extra | backend seam | yes | ✅ both backends |
-| `doc-kg` | 0.19.1 | **hard** | `index.py` | yes (8 files) | ⚠ justified — it *is* the converter |
-| `diary-kg` | 0.93.4 | **hard** | **0 files** | 0 files | ⚠ **dead dependency** |
-| `memory-kg` | 0.6.2 | **hard** | `index.py` | **0 files** | ✖ **un-migrated** |
+| `doc-kg` | 0.19.1 | **hard** | `index.py` | yes (8 files) | 🔴 plan Phase 4 — both backends wired |
+| `diary-kg` | 0.93.4 | **hard** | 0 files | 0 files | 🟢 plan Phase 1 — see correction |
+| `memory-kg` | 0.6.2 | **hard** | `index.py` | **0 files** | 🟠 plan Phase 3 |
+| `Metabo_kg` | — | — | — | — | 🟡 plan Phase 2 — **not on PyPI**, unaudited here |
 
-Three actions fall out, in ascending cost:
+**Correction — `diary-kg` is not just a dead dependency.** An earlier revision of
+this section claimed dropping `lancedb` from diary-kg was "a one-line release
+with no code change", on the basis that the published wheel contains zero
+`import lancedb`. That is true but misleading: diary-kg never imports lancedb
+because it *delegates* vector work to `dockg build` — while still passing
+`--lancedb` paths to that subprocess (`diary_kg/kg.py:291`, `:367`) and
+plumbing `self._lancedb_dir` throughout. The plan counts 30 lancedb source refs
+and 2 `--lancedb` CLI refs, and sizes it as a real Phase-1 port (rename flags,
+swap the artifact path, port the read/write paths by hand — `DiaryKGAdapter`
+only *mirrors* the `KGModule` pattern without subclassing it, so there is no
+seam to flip). **A wheel-level grep cannot see CLI strings, prose, tests or
+docs — prefer the plan's repo-level counts.**
 
-1. **`diary-kg` declares `lancedb>=0.29.0` and never imports it** — it delegates
-   all vector work to doc-kg. Dropping the dep is a one-line release with no code
-   change, and it removes lancedb from every diary worker image (this is what
-   corpus_pepys hit; see below).
-2. **`doc-kg`'s hard dep is legitimate for now** — `index.py` needs lancedb to
-   *read* LanceDB in `dockg convert-index`. It should become an extra
-   (`[lancedb]`) once the fleet has finished converting, so fresh installs stop
-   pulling it.
-3. **`memory-kg` 0.6.2 is genuinely un-migrated** — LanceDB-only `index.py`, and
-   its CLI has no `--vectors-path` / `--vector-backend` at all. **Do not convert
-   a memory KG's vectors**: memory-kg cannot read a `vectors.sqlite` store, so
-   converting one silently strands it. Porting `memory_kg/index.py` onto the
-   `kg_utils.vector_backend` seam (as pycode-kg/ftree-kg/agent-kg already are) is
-   the real work item.
+What the package audit does add, being 2 days newer than the plan:
 
-`kgrag` itself is clean: no `import lancedb` anywhere in `src/`. The one live
-defect found in this repo was `cmd_health.py`'s probe templates (stale `codekg`
-binary, `-k` vs `--k`, and an empty `--lancedb` value swallowing the next
-token) — fixed in `[Unreleased]`.
+1. **`memory-kg` 0.6.2's CLI has no sqlite-vec surface at all** — no
+   `--vectors-path`, no `--vector-backend`, and it hard-requires
+   `lancedb>=0.29.0`. So until plan Phase 3 lands, **do not convert a memory
+   KG's vectors**: memory-kg cannot read the result. (The plan adds a caveat
+   worth heeding first — memory_kg resolves `kgmodule-utils` via a **path
+   dependency**, so confirm which checkout it uses before assuming it even has
+   the 0.8.0 backend seam.)
+2. **`doc-kg` 0.19.1 already ships `--vectors-path` and `--vector-backend auto`**
+   on its vector-touching CLI commands. The plan (Phase 4) notes doc_kg is the
+   one repo where *keeping* LanceDB is defensible, since `index.py` needs it to
+   read LanceDB during `dockg convert-index`.
+3. **`gutenberg_kg` needs a re-audit after diary_kg and doc_kg land.** Its own
+   store is already sqlite-vec, but per the plan its 41 lancedb refs are it
+   *orchestrating* other KGs (`ingest.py` builds `.dockg/lancedb` and
+   `.diarykg/lancedb`) — correct today, stale only once those two migrate.
+
+`kgrag` itself is clean: no `import lancedb` anywhere in `src/`. The plan agrees
+it is **not a migration target** — the registry deliberately spans both backends
+(`lancedb_path` + `vectors_path` columns), and dropping `lancedb_path` is the
+*final* step of the whole fleet migration, valid only once every registered KG
+reports a `vectors_path`. Until then the column is load-bearing. Re-register KGs
+after each repo migrates.
+
+**The `cmd_health.py` probe bug the plan flagged is fixed** (see
+`[Unreleased]`). `MIGRATION-sqlite-vec.md` found it independently while
+auditing — *"`codekg` is the retired predecessor of `pycode_kg` and is not on
+PATH … every code-KG liveness probe silently fails"* — and prescribed
+`pycodekg query --sqlite {sqlite} --vectors {vectors}`, which is what landed.
+Two notes where the fix goes beyond the plan's prescription:
+
+- The plan says the `doc` and `memory` entries need the same
+  `--lancedb` → `--vectors` treatment *"once those repos migrate"*. **`doc` was
+  done now, not deferred**, because doc-kg 0.19.1 already accepts
+  `--vectors-path` — the flag is chosen from whichever path the registry
+  records, so it is correct both before and after doc_kg's Phase 4. **`memory`
+  deliberately still passes `--lancedb`**, per plan Phase 3 being outstanding.
+- Two further defects in those templates were unrelated to backends and hit
+  every kind regardless of migration state: `-k` is not a valid option on any of
+  these Click CLIs (only `--k`), and interpolating an empty `--lancedb` value
+  made the flag swallow the following token under `shlex.split`.
 
 ### Remaining coordination
 
@@ -124,10 +167,14 @@ token) — fixed in `[Unreleased]`.
   doc-kg/diary-kg releases that demote lancedb to an optional extra; also
   cosmetic: `diarykg build` still prints a "LanceDB :" path label while writing
   `vectors.sqlite`.
-- **`gutenberg_kg` is migrated** — reported by the maintainer 2026-07-30 (done
-  outside this repo, so unverified here). Its pins are already
-  `kgmodule-utils[synthesis,sqlite-vec]>=0.8.0` / `doc-kg>=0.18.1` on `main`.
-  This invalidates the largest row of the audit table above (237 gutenberg
-  corpora counted as `unmigrated` on 2026-07-26) — **re-run `kgrag
+- **`gutenberg_kg`'s own store is migrated** — maintainer-reported 2026-07-30 and
+  corroborated by `MIGRATION-sqlite-vec.md` ("✅ own store done",
+  `vector_backend="sqlite-vec"`). Its pins on `main` are
+  `kgmodule-utils[synthesis,sqlite-vec]>=0.8.0` / `doc-kg>=0.18.1`, and its
+  worker already reads sqlite-vec (`_open_vector_source` prefers
+  `SqliteVecBackend`). This invalidates the largest row of the 2026-07-26 audit
+  table above (237 gutenberg corpora as `unmigrated`) — **re-run `kgrag
   audit-lancedb` for current numbers before treating that table as fleet
-  state.**
+  state.** Note the plan's ordering dependency: gutenberg_kg's remaining lancedb
+  references are it *orchestrating* other KGs' stores, so **re-audit it once
+  `diary_kg` and `doc_kg` land**.

--- a/TODO.md
+++ b/TODO.md
@@ -56,6 +56,45 @@ Fixed upstream in **doc-kg 0.18.2** (`DocKG(vectors_path=...)`, plus a
 here; the kgrag floor is now `doc-kg>=0.18.2`. `vectors_path` is authoritative
 for every KG kind.
 
+### Fleet code-migration audit — 2026-07-30
+
+Measured against the **published packages** (installed from PyPI and grepped for
+real code paths, not just declared deps). This is about *code*, not on-disk
+vector artifacts — artifacts are regenerable, stale code is not.
+
+| Package | Version | `lancedb` dep | imports `lancedb` | sqlite-vec aware | Verdict |
+|---|---|---|---|---|---|
+| `pycode-kg` | 0.21.2 | none | 0 files | yes | ✅ migrated |
+| `ftree-kg` | 0.9.0 | none | 0 files | yes | ✅ migrated |
+| `agent-kg` | 0.8.2 | none | 0 files | yes | ✅ migrated |
+| `tscode-kg` | 0.2.0 | none | 0 files | yes | ✅ migrated |
+| `kgmodule-utils` | 0.9.0 | `[semantic]` extra | backend seam | yes | ✅ both backends |
+| `doc-kg` | 0.19.1 | **hard** | `index.py` | yes (8 files) | ⚠ justified — it *is* the converter |
+| `diary-kg` | 0.93.4 | **hard** | **0 files** | 0 files | ⚠ **dead dependency** |
+| `memory-kg` | 0.6.2 | **hard** | `index.py` | **0 files** | ✖ **un-migrated** |
+
+Three actions fall out, in ascending cost:
+
+1. **`diary-kg` declares `lancedb>=0.29.0` and never imports it** — it delegates
+   all vector work to doc-kg. Dropping the dep is a one-line release with no code
+   change, and it removes lancedb from every diary worker image (this is what
+   corpus_pepys hit; see below).
+2. **`doc-kg`'s hard dep is legitimate for now** — `index.py` needs lancedb to
+   *read* LanceDB in `dockg convert-index`. It should become an extra
+   (`[lancedb]`) once the fleet has finished converting, so fresh installs stop
+   pulling it.
+3. **`memory-kg` 0.6.2 is genuinely un-migrated** — LanceDB-only `index.py`, and
+   its CLI has no `--vectors-path` / `--vector-backend` at all. **Do not convert
+   a memory KG's vectors**: memory-kg cannot read a `vectors.sqlite` store, so
+   converting one silently strands it. Porting `memory_kg/index.py` onto the
+   `kg_utils.vector_backend` seam (as pycode-kg/ftree-kg/agent-kg already are) is
+   the real work item.
+
+`kgrag` itself is clean: no `import lancedb` anywhere in `src/`. The one live
+defect found in this repo was `cmd_health.py`'s probe templates (stale `codekg`
+binary, `-k` vs `--k`, and an empty `--lancedb` value swallowing the next
+token) — fixed in `[Unreleased]`.
+
 ### Remaining coordination
 
 - **`kgrag_priv` still carries the 0.10.1 adapter stopgap** — port this change

--- a/src/kg_rag/cli/cmd_health.py
+++ b/src/kg_rag/cli/cmd_health.py
@@ -95,14 +95,20 @@ _PROBE_CMD_TPL: dict[str, str] = {
     "diary": "diarykg status {repo}",
 }
 
-# Vector-store flag per kind — each module's CLI names it differently.
-# pycode-kg dropped ``--lancedb`` entirely at 0.20 (sqlite-vec only); the doc
-# family accepts either and resolves with ``--vector-backend auto``.
+# Vector-store flag per kind — each module's CLI names it differently, and not
+# every module has migrated:
+#   * pycode-kg >=0.20 is sqlite-vec only — ``--lancedb`` no longer exists.
+#   * doc-kg >=0.18.2 accepts either and resolves with ``--vector-backend auto``.
+#   * memory-kg 0.6.2 (current) is LanceDB *only* — no ``--vectors-path``, no
+#     ``--vector-backend``, and it hard-requires ``lancedb>=0.29.0``. A memory KG
+#     whose vectors were converted to sqlite-vec cannot be read by its own CLI,
+#     so the probe passes no vector flag and the resulting failure is real
+#     signal, not a malformed command. Revisit when memory-kg gains sqlite-vec.
 _VEC_FLAGS: dict[str, tuple[str | None, str | None]] = {
     # kind: (flag for vectors_path, flag for lancedb_path)
     "code": ("--vectors", None),
     "doc": ("--vectors-path", "--lancedb"),
-    "memory": ("--vectors-path", "--lancedb"),
+    "memory": (None, "--lancedb"),
 }
 
 

--- a/src/kg_rag/cli/cmd_health.py
+++ b/src/kg_rag/cli/cmd_health.py
@@ -59,7 +59,7 @@ _SEVERITY_ICON: dict[str, str] = {"critical": "✖", "warning": "⚠", "info": "
 # ---------------------------------------------------------------------------
 
 _BUILD_CMD_TPL: dict[str, str] = {
-    "code": "codekg build --repo {repo}",
+    "code": "pycodekg build --repo {repo}",
     "doc": "dockg build --repo {repo}",
     "memory": "memorykg-build --repo {repo}",
     "diary": "diarykg build --repo {repo}",
@@ -89,11 +89,42 @@ def _build_cmd(kind: str, repo: Path) -> str:
 # ---------------------------------------------------------------------------
 
 _PROBE_CMD_TPL: dict[str, str] = {
-    "code": "codekg query --sqlite {sqlite} --lancedb {lancedb} -k 1 health",
-    "doc": "dockg query --sqlite {sqlite} --lancedb {lancedb} -k 1 health",
-    "memory": "memorykg query --sqlite {sqlite} --lancedb {lancedb} -k 1 health",
+    "code": "pycodekg query --sqlite {sqlite} {vec} --k 1 health",
+    "doc": "dockg query --sqlite {sqlite} {vec} --k 1 health",
+    "memory": "memorykg query --sqlite {sqlite} {vec} --k 1 health",
     "diary": "diarykg status {repo}",
 }
+
+# Vector-store flag per kind — each module's CLI names it differently.
+# pycode-kg dropped ``--lancedb`` entirely at 0.20 (sqlite-vec only); the doc
+# family accepts either and resolves with ``--vector-backend auto``.
+_VEC_FLAGS: dict[str, tuple[str | None, str | None]] = {
+    # kind: (flag for vectors_path, flag for lancedb_path)
+    "code": ("--vectors", None),
+    "doc": ("--vectors-path", "--lancedb"),
+    "memory": ("--vectors-path", "--lancedb"),
+}
+
+
+def _vec_arg(kind: str, entry: KGEntry) -> str:
+    """Return the vector-store CLI argument for *entry*, or ``""`` if unrecorded.
+
+    Never returns a bare flag.  An empty value collapses under
+    :func:`shlex.split`, which makes the flag swallow the *next* token — the
+    old ``--lancedb {lancedb} -k 1`` template consumed ``-k`` exactly that way
+    for every migrated KG.  Omitting the flag instead lets each CLI apply its
+    own default layout.
+
+    :param kind: KG kind string (e.g. ``"code"``).
+    :param entry: Registry entry supplying the recorded store paths.
+    :return: Shell-quoted ``"--flag /path"``, or an empty string.
+    """
+    vec_flag, lance_flag = _VEC_FLAGS.get(kind, (None, None))
+    if vec_flag and entry.vectors_path:
+        return f"{vec_flag} {shlex.quote(str(entry.vectors_path))}"
+    if lance_flag and entry.lancedb_path:
+        return f"{lance_flag} {shlex.quote(str(entry.lancedb_path))}"
+    return ""
 
 
 def _probe_kg(entry: KGEntry) -> str | None:
@@ -109,18 +140,20 @@ def _probe_kg(entry: KGEntry) -> str | None:
     fail, only the MCP server restart is needed.
 
     :param entry: KGEntry with ``kind``, ``repo_path``, ``sqlite_path``, and
-        ``lancedb_path`` attributes.
+        ``vectors_path`` / ``lancedb_path`` attributes.
     :return: Error description string, or ``None`` if the probe passes.
     """
     kind = entry.kind.value
     tpl = _PROBE_CMD_TPL.get(kind)
     if tpl is None:
         return None  # no probe available for this kind
+    if "{sqlite}" in tpl and not entry.sqlite_path:
+        return None  # no graph recorded — nothing to probe against
 
     cmd = tpl.format(
-        sqlite=entry.sqlite_path or "",
-        lancedb=entry.lancedb_path or "",
-        repo=entry.repo_path,
+        sqlite=shlex.quote(str(entry.sqlite_path)) if entry.sqlite_path else "",
+        vec=_vec_arg(kind, entry),
+        repo=shlex.quote(str(entry.repo_path)),
     )
     try:
         result = subprocess.run(shlex.split(cmd), capture_output=True, timeout=30)

--- a/tests/test_cmd_health.py
+++ b/tests/test_cmd_health.py
@@ -720,6 +720,20 @@ class TestProbeCommandConstruction:
         assert "--lancedb" in argv
         assert str(lancedb_dir.resolve()) in argv
 
+    def test_memory_probe_never_passes_vectors_path(self, tmp_path):
+        """memory-kg 0.6.2 is LanceDB-only — it has no --vectors-path option.
+
+        Passing one aborts the probe on "No such option". A migrated memory KG
+        gets no vector flag at all; the ensuing failure is real signal, because
+        memory-kg genuinely cannot read a sqlite-vec store.
+        """
+        repo = tmp_path / "memory-repo"
+        repo.mkdir(exist_ok=True)
+        entry = self._entry(tmp_path, KGKind.MEMORY, vectors_path=repo / "vectors.sqlite")
+        argv = self._argv(entry)
+        assert "--vectors-path" not in argv
+        assert "--vectors" not in argv
+
     # ── the empty-value bug ─────────────────────────────────────────────────
 
     def test_no_flag_emitted_without_a_recorded_store(self, tmp_path):

--- a/tests/test_cmd_health.py
+++ b/tests/test_cmd_health.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
+from kg_rag.cli.cmd_health import _build_cmd, _probe_kg
 from kg_rag.cli.main import cli
 from kg_rag.corpus_registry import CorpusRegistry
 from kg_rag.primitives import CorpusEntry, KGEntry, KGKind
@@ -119,7 +120,7 @@ class TestHealthUnbuilt:
             reg.register(entry)
 
         result = _runner().invoke(cli, ["health"] + _reg_args(db))
-        assert "codekg build" in result.output
+        assert "pycodekg build" in result.output
 
     def test_doc_kg_suggests_dockg_build(self, tmp_path):
         db = _reg_db(tmp_path)
@@ -400,7 +401,7 @@ class TestHealthFixSubprocess:
         assert result.exit_code == 0
         mock_popen.assert_called_once()
         called_cmd = mock_popen.call_args[0][0]
-        assert called_cmd[0] == "codekg"
+        assert called_cmd[0] == "pycodekg"  # renamed binary; no `codekg` since 0.14
         assert "build" in called_cmd
 
     def test_fix_shows_streaming_output(self, tmp_path):
@@ -462,7 +463,7 @@ class TestHealthFixSubprocess:
         repo.mkdir()
         # SQLite path registered but missing → stale_sqlite
         # LanceDB path registered but missing → stale_lancedb
-        # Both map to the same "codekg build --repo ..." command.
+        # Both map to the same "pycodekg build --repo ..." command.
         db_dir = repo / ".pycodekg"
         db_dir.mkdir()
         sqlite = db_dir / "graph.sqlite"
@@ -599,7 +600,7 @@ class TestHealthLanceDBProbe:
 
         data = json.loads(result.output)
         issue = next(i for i in data["issues"] if i["check"] == "stale_lancedb_probe")
-        assert "codekg build" in (issue["fix_cmd"] or "")
+        assert "pycodekg build" in (issue["fix_cmd"] or "")
 
     def test_probe_command_not_found_surfaces_issue(self, tmp_path):
         """If the module binary is not on PATH, probe surfaces a critical issue."""
@@ -630,3 +631,119 @@ class TestHealthLanceDBProbe:
         issue = next(i for i in data["issues"] if i["check"] == "stale_lancedb_probe")
         msg = issue["message"].lower()
         assert "mcp" in msg or "restart" in msg
+
+
+# ---------------------------------------------------------------------------
+# Probe command construction
+#
+# The tests above all patch _probe_kg, so none of them ever exercised the
+# command templates themselves — which is how a stale binary name (`codekg`),
+# a nonexistent flag (`--lancedb` on pycode-kg >=0.20), and a wrong short
+# option (`-k`, rejected by every module's Click CLI) survived unnoticed.
+# These assert the argv the probe would actually run.
+# ---------------------------------------------------------------------------
+
+
+class TestProbeCommandConstruction:
+    def _argv(self, entry: KGEntry) -> list[str]:
+        """Return the argv _probe_kg would execute for *entry*."""
+        with patch("subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stderr=b"")
+            _probe_kg(entry)
+            assert run.called, "probe did not run a command"
+            return run.call_args[0][0]
+
+    def _entry(self, tmp_path: Path, kind: KGKind, **paths) -> KGEntry:
+        repo = tmp_path / f"{kind.value}-repo"
+        repo.mkdir(exist_ok=True)
+        sqlite = repo / "graph.sqlite"
+        sqlite.touch()
+        return KGEntry(
+            name=f"{kind.value}-kg",
+            kind=kind,
+            repo_path=repo,
+            venv_path=repo / ".venv",
+            sqlite_path=sqlite,
+            **paths,
+        )
+
+    # ── binary names ────────────────────────────────────────────────────────
+
+    def test_code_probe_uses_pycodekg_binary(self, tmp_path):
+        """pycode-kg ships `pycodekg`; there has been no `codekg` binary since 0.14."""
+        entry = self._entry(tmp_path, KGKind.CODE)
+        assert self._argv(entry)[0] == "pycodekg"
+
+    def test_code_build_cmd_uses_pycodekg_binary(self, tmp_path):
+        assert _build_cmd("code", tmp_path).startswith("pycodekg build")
+
+    # ── option spelling ─────────────────────────────────────────────────────
+
+    def test_no_probe_uses_short_k_option(self, tmp_path):
+        """`-k` is rejected by these Click CLIs — the long `--k` is required."""
+        for kind in (KGKind.CODE, KGKind.DOC, KGKind.MEMORY):
+            argv = self._argv(self._entry(tmp_path, kind))
+            assert "-k" not in argv, f"{kind.value}: bare -k is not a valid option"
+            assert "--k" in argv, f"{kind.value}: expected --k"
+
+    def test_code_probe_never_passes_lancedb_flag(self, tmp_path):
+        """pycode-kg >=0.20 has no --lancedb; passing it aborts the probe."""
+        entry = self._entry(tmp_path, KGKind.CODE, lancedb_path=tmp_path / "code-repo" / "lancedb")
+        assert "--lancedb" not in self._argv(entry)
+
+    # ── vector store selection ──────────────────────────────────────────────
+
+    def test_code_probe_passes_vectors_path(self, tmp_path):
+        vectors = tmp_path / "code-repo" / "vectors.sqlite"
+        entry = self._entry(tmp_path, KGKind.CODE, vectors_path=vectors)
+        argv = self._argv(entry)
+        assert "--vectors" in argv
+        assert str(vectors.resolve()) in argv
+
+    def test_doc_probe_prefers_vectors_path_over_lancedb(self, tmp_path):
+        repo = tmp_path / "doc-repo"
+        repo.mkdir(exist_ok=True)
+        vectors = repo / "vectors.sqlite"
+        entry = self._entry(
+            tmp_path, KGKind.DOC, vectors_path=vectors, lancedb_path=repo / "lancedb"
+        )
+        argv = self._argv(entry)
+        assert "--vectors-path" in argv
+        assert "--lancedb" not in argv
+
+    def test_doc_probe_falls_back_to_lancedb_when_unmigrated(self, tmp_path):
+        repo = tmp_path / "doc-repo"
+        repo.mkdir(exist_ok=True)
+        lancedb_dir = repo / "lancedb"
+        entry = self._entry(tmp_path, KGKind.DOC, lancedb_path=lancedb_dir)
+        argv = self._argv(entry)
+        assert "--lancedb" in argv
+        assert str(lancedb_dir.resolve()) in argv
+
+    # ── the empty-value bug ─────────────────────────────────────────────────
+
+    def test_no_flag_emitted_without_a_recorded_store(self, tmp_path):
+        """A bare flag would swallow the following token under shlex.split."""
+        argv = self._argv(self._entry(tmp_path, KGKind.DOC))
+        assert "--lancedb" not in argv
+        assert "--vectors-path" not in argv
+
+    def test_every_flag_has_a_value(self, tmp_path):
+        """No flag may be followed by another flag or sit at the end of argv."""
+        for kind in (KGKind.CODE, KGKind.DOC, KGKind.MEMORY):
+            argv = self._argv(self._entry(tmp_path, kind))
+            for i, tok in enumerate(argv):
+                if tok.startswith("--") and tok != "--include-symbols":
+                    assert i + 1 < len(argv), f"{kind.value}: {tok} has no value"
+                    assert not argv[i + 1].startswith("-"), (
+                        f"{kind.value}: {tok} swallowed {argv[i + 1]}"
+                    )
+
+    def test_probe_skipped_without_sqlite_path(self, tmp_path):
+        """Nothing to probe against — must not build a command with an empty path."""
+        repo = tmp_path / "no-graph"
+        repo.mkdir(exist_ok=True)
+        entry = KGEntry(name="no-graph", kind=KGKind.DOC, repo_path=repo, venv_path=repo / ".venv")
+        with patch("subprocess.run") as run:
+            assert _probe_kg(entry) is None
+            assert not run.called


### PR DESCRIPTION
## Summary

Three independent fixes found while chasing the sqlite-vec **code** migration (as opposed to on-disk vector artifacts, which are regenerable).

### 1. `kgrag health` probed every code/doc/memory KG with a broken command

`_probe_kg` reported a false `stale_lancedb_probe` critical on healthy KGs. Three defects, each verified against the installed CLIs (pycode-kg 0.21.2, doc-kg 0.19.1, memory-kg 0.6.2) rather than assumed:

| Defect | Effect |
|---|---|
| `-k 1` is not a valid option — these Click CLIs declare only `--k` | Every probe died on `Error: No such option '-k'` before reading an index. Hit all three kinds regardless of migration state. |
| `codekg` is not a binary — pycode-kg ships `pycodekg` (renamed at 0.14) | Code probe and code build-fix failed with "command not found". `cmd_audit.py` already had the right name; `cmd_health.py` was missed in the rename. |
| `--lancedb {lancedb}` interpolated `""` for migrated KGs | An empty value collapses under `shlex.split`, so the flag consumed `-k`. pycode-kg ≥0.20 has no `--lancedb` at all. |

The probe now derives the vector flag from what the registry actually records — `--vectors` for code, `--vectors-path`/`--lancedb` for the doc family, `--lancedb` only for memory — omits it entirely when no store is recorded, shell-quotes paths, and skips KGs with no graph.

**memory-kg is deliberately left on `--lancedb`:** 0.6.2 is LanceDB-only (no `--vectors-path`, no `--vector-backend`, hard `lancedb>=0.29.0`, zero sqlite-vec refs in source). A converted memory KG cannot be probed at all, so the failure there is real signal rather than a malformed command.

### 2. GitHub releases were titled "CodeKG"

`release.yml` hardcoded `gh release create --title "CodeKG $TAG"` — a copy-paste from the code-kg repo, so every published KGRAG release carried the wrong product name. **v0.11.0 is still titled "CodeKG v0.11.0" on GitHub and needs a manual retitle** (`gh release edit v0.11.0 --title "KGRAG v0.11.0"`); this stops it recurring.

### 3. `TODO.md` reconciled against the plan of record

`pycode_kg/MIGRATION-sqlite-vec.md` is the authoritative migration plan; `TODO.md` now defers to it instead of asserting a parallel account. That document independently found the same `cmd_health.py` bug and prescribed the same fix shape.

Corrections made:
- **diary-kg was wrongly called a "dead dependency"** droppable in a one-line release, inferred from its wheel having zero `import lancedb`. It delegates to `dockg build` but still passes `--lancedb` paths to that subprocess and plumbs `self._lancedb_dir` throughout; the plan counts 30 source refs and sizes it as a real Phase-1 port. A wheel-level grep cannot see CLI strings, prose, tests, or docs.
- The kgmodule-utils note cited **0.7.0** as "planning" to split `lancedb` out of `[semantic]`. 0.7.0 shipped long ago, 0.9.0 is current, and `lancedb>=0.19.0` is *still* in `[semantic]` — the split has not landed.
- **`gutenberg_kg` is migrated**, which invalidates the 237-gutenberg row of the 2026-07-26 audit table (now flagged stale, with a pointer to re-run `kgrag audit-lancedb`).
- Recorded that `memory_kg` resolves `kgmodule-utils` via a **path dependency**, that `gutenberg_kg` needs re-auditing once diary_kg and doc_kg land, and that **kgrag is not a migration target** — dropping `lancedb_path` is the final step, valid only once every registered KG reports a `vectors_path`.

## Testing

- **497 tests pass** on Python 3.12; `ruff check` and `ruff format --check` clean.
- New argv-level tests in `tests/test_cmd_health.py`. The existing probe tests all patched `_probe_kg`, so **no test ever exercised a command template** — which is how this survived. Added coverage asserts binary names, `--k` spelling, per-kind vector-flag selection, and that no flag is ever emitted without a value.
- One pre-existing test asserted the `codekg` binary name and was corrected; two others passed only because `"pycodekg build"` contains `"codekg build"` as a substring, and were tightened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaBVS1zDC7QQumo8UyAWYT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaBVS1zDC7QQumo8UyAWYT)_