### PR TITLE
TODO: fix three stale pointers and one self-contradiction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ago and 0.9.0 is current, where `lancedb>=0.19.0` is *still* in `[semantic]`.
   Also records that `gutenberg_kg` is migrated, which invalidates the
   237-gutenberg row of the 2026-07-26 audit table (now flagged stale).
+- **`TODO.md` staleness pass** — three defects that misdirected readers:
+  both "see CHANGELOG `[Unreleased]`" pointers referred to work that shipped in
+  `[0.11.0]`, so they now landed on unrelated content (the health fixes above);
+  the LanceDB-retirement heading asserted "~96% un-migrated" directly above the
+  note retracting that figure; and the doc-kg/diary-kg coordination bullet still
+  implied the migration was two dependency demotions, contradicting the
+  diary-kg correction 80 lines earlier. Finished work is now collapsed into a
+  "Landed — no action required" section instead of occupying the first third of
+  the file, and the in-place `dockg convert-index` advice carries the plan's
+  delete-and-rebuild counterpoint plus its two pre-flight guards (capture
+  queries before deleting; reconcile node count against index count).
 - **`TODO.md` fleet audit reconciled against `pycode_kg`'s
   `MIGRATION-sqlite-vec.md`** — that document is the plan of record (phases,
   per-repo effort, reference-implementation checklist) and `TODO.md` now defers

--- a/TODO.md
+++ b/TODO.md
@@ -1,33 +1,35 @@
 # KGRAG TODO
 
-## Registry schema: `KGEntry.lancedb_path` models a retired store — RESOLVED
+## Landed — no action required
 
-**Filed 2026-07-26 from `pycode_kg`. Resolved 2026-07-26 (see CHANGELOG
-`[Unreleased]`).**
+- **`KGEntry.vectors_path` is a first-class registry field** (filed 2026-07-26
+  from `pycode_kg`, resolved same day, **shipped in 0.11.0** — see CHANGELOG
+  `[0.11.0]`). Added to `KGEntry` and the schema with an in-place `_migrate()`;
+  `lancedb_path` stays readable for kinds that still ship LanceDB but is no
+  longer written for code KGs; auto-detection probes `<db_dir>/vectors.sqlite`
+  first; `CodeKGAdapter._load` reads `entry.vectors_path` directly instead of
+  guessing a sibling of `lancedb_path`; `kgrag export`/`import` bundle the
+  file-shaped store so code-KG bundles no longer ship without their vectors.
+- **Doc-family adapters can pass a non-default vector-store location**
+  (closed 2026-07-26, **shipped in 0.11.0**). `DocKGAdapter`/
+  `GutenbergKGAdapter` previously made `vectors_path` informational only for
+  doc KGs. Fixed upstream in **doc-kg 0.18.2** (`DocKG(vectors_path=...)` plus
+  `--vectors-path` on the 8 vector-touching CLI commands) and wired through
+  here; the kgrag floor is `doc-kg>=0.18.2`. `vectors_path` is now
+  authoritative for every KG kind.
 
-`KGEntry` now carries a first-class `vectors_path` (plus a `vectors_path TEXT`
-column and an in-place `_migrate()` step). All five suggested steps landed:
+## LanceDB retirement — fleet state needs re-measuring
 
-1. `vectors_path` added to `KGEntry` and the registry schema, migrated in place.
-2. `lancedb_path` stays readable for kinds that still ship LanceDB, but is no
-   longer written for code KGs; `--lancedb` deprecated in favour of `--vectors`.
-3. Auto-detection probes `<db_dir>/vectors.sqlite`, falling back to
-   `<db_dir>/lancedb` only for kinds that still use it.
-4. The sibling-derivation guess is gone from `CodeKGAdapter._load` — it reads
-   `entry.vectors_path` directly (defaulting to the standard `.pycodekg/` layout
-   when the registry has no recorded path, so pre-existing entries keep working).
-5. `kgrag export`/`import` bundle the file-shaped vector store; code-KG corpus
-   bundles no longer ship without their vectors.
+> **The figures below are from 2026-07-26 and are known stale** — the gutenberg
+> corpora have since migrated (see Remaining coordination), which invalidates
+> the largest row. **Re-run `kgrag audit-lancedb` before quoting any of it.**
+> For the *code* migration — which repo ships which backend, in what order —
+> the plan of record is `pycode_kg/MIGRATION-sqlite-vec.md`; see the audit
+> section below.
 
-## LanceDB retirement — fleet is still ~96% un-migrated
-
-`kgrag audit-lancedb` (added alongside the above) measured the real registry on
-2026-07-26: **242 of 253 KGs still have LanceDB as their live vector index**,
-holding **~2.0 GB** on disk. It is not gone — the schema work above only stopped
-kgrag *recording* it for new code KGs.
-
-> **Stale as of 2026-07-30** — the gutenberg corpora have since been migrated
-> (see Remaining coordination). Re-run the audit for real numbers.
+`kgrag audit-lancedb` measured the real registry on 2026-07-26: **242 of 253
+KGs still had LanceDB as their live vector index**, holding ~2.0 GB on disk.
+The schema work above only stopped kgrag *recording* it for new code KGs.
 
 | Status | KGs | Note |
 |---|---|---|
@@ -47,14 +49,14 @@ kgrag audit-lancedb --commands   # review, then pipe to a shell
   straight out of LanceDB, so there is **no re-embedding**.
 - code KGs have no converter; they need a `pycodekg build`.
 
-### Known gap — CLOSED 2026-07-26
-
-`DocKGAdapter`/`GutenbergKGAdapter` could not pass a non-default vector-store
-location, so `KGEntry.vectors_path` was informational only for doc-family KGs.
-Fixed upstream in **doc-kg 0.18.2** (`DocKG(vectors_path=...)`, plus a
-`--vectors-path` option on the 8 vector-touching CLI commands) and wired through
-here; the kgrag floor is now `doc-kg>=0.18.2`. `vectors_path` is authoritative
-for every KG kind.
+> **The plan of record takes the opposite line on conversion**, and it is the
+> one to follow: vector stores are derived artifacts, so
+> `MIGRATION-sqlite-vec.md` says **delete and rebuild** rather than convert.
+> Two guards it insists on first, because they are what caught `agent_kg` out:
+> capture query results *before* deleting (you cannot compare against a store
+> you removed), and reconcile `SELECT COUNT(*) FROM nodes` against
+> `backend.count()` — every `.agentkg` index had drifted 15–100%, so parity
+> looked *better* after migrating purely because the control was incomplete.
 
 ### Fleet code-migration audit — 2026-07-30
 
@@ -159,14 +161,23 @@ Two notes where the fix goes beyond the plan's prescription:
   `lancedb` from `[semantic]` in a future kgmodule-utils release.
 - **doc-kg / diary-kg still hard-require `lancedb>=0.29.0`** (checked 2026-07-30
   at doc-kg 0.19.1 / diary-kg 0.93.4, filed from `corpus_pepys`). This is the
-  binding constraint: unlike the kgmodule-utils case above, it is an
-  unconditional dependency, so lancedb lands in every worker image no matter
+  binding constraint for *installs*: unlike the kgmodule-utils case above, it is
+  an unconditional dependency, so lancedb lands in every worker image no matter
   which extras are selected. corpus_pepys no longer *imports* lancedb anywhere
   (worker is sqlite-vec only, LanceDB fallback removed, merged as
-  corpus_pepys#1), but the package is still installed. Full retirement needs
-  doc-kg/diary-kg releases that demote lancedb to an optional extra; also
-  cosmetic: `diarykg build` still prints a "LanceDB :" path label while writing
-  `vectors.sqlite`.
+  corpus_pepys#1), but the package is still installed.
+
+  **The dependency drop is an *outcome* of each repo's migration, not a
+  shortcut past it** — see the audit section above. It is tempting to read this
+  bullet as "two releases demote an extra and we are done"; that was the
+  diary-kg mistake corrected there. Per the plan, diary-kg is a real Phase-1
+  port (30 lancedb source refs, 2 `--lancedb` CLI refs, no `KGModule` seam to
+  flip) and doc-kg is Phase 4. Sequence the work from
+  `MIGRATION-sqlite-vec.md`; the `pyproject.toml` edit is step 6 of 8 in its
+  checklist, not the whole job.
+
+  Also cosmetic, and unblocked by any of the above: `diarykg build` still
+  prints a "LanceDB :" path label while writing `vectors.sqlite`.
 - **`gutenberg_kg`'s own store is migrated** — maintainer-reported 2026-07-30 and
   corroborated by `MIGRATION-sqlite-vec.md` ("✅ own store done",
   `vector_backend="sqlite-vec"`). Its pins on `main` are


### PR DESCRIPTION
## Summary

Docs-only. `TODO.md` had three defects that would misdirect a reader, found by re-reading it after #14 merged.

### 1. Both `[Unreleased]` pointers were stale

Two sections said "see CHANGELOG `[Unreleased]`" for the `vectors_path` work — but that shipped in **`[0.11.0]`** on 2026-07-29 (`vectors_path` at CHANGELOG:80, `audit-lancedb` at :70). `[Unreleased]` now holds the health-probe fixes from #14, so anyone following those pointers landed on unrelated content. Retargeted to `[0.11.0]`.

### 2. A heading asserted the number its own warning retracted

> ## LanceDB retirement — fleet is still ~96% un-migrated
>
> > **Stale as of 2026-07-30** — the gutenberg corpora have since been migrated…

Headings are what get skimmed. The heading no longer carries a figure ("fleet state needs re-measuring"), and the staleness warning now leads the section rather than trailing the claim.

### 3. A coordination bullet contradicted the correction 80 lines above it

The doc-kg/diary-kg bullet framed full LanceDB retirement as *"releases that demote lancedb to an optional extra"* — precisely the misconception the audit section corrects for diary-kg in #14. It now states that the dependency drop is an **outcome** of each repo's migration, not a shortcut past it (step 6 of 8 in the plan's checklist), and points at the phases: diary-kg is a real Phase-1 port with 30 source refs and no `KGModule` seam; doc-kg is Phase 4.

## Also

- Finished work is collapsed into a **"Landed — no action required"** section. Two RESOLVED/CLOSED entries from 2026-07-26 previously occupied the first third of the file, ahead of anything actionable.
- The in-place `dockg convert-index` guidance now carries the plan's **delete-and-rebuild counterpoint** — vector stores are derived artifacts — plus its two pre-flight guards, which are what caught `agent_kg` out: capture query results *before* deleting, and reconcile `SELECT COUNT(*) FROM nodes` against `backend.count()`. Every `.agentkg` index had drifted 15–100%, so parity looked *better* after migrating purely because the control was an incomplete index.

## Testing

No code changed. 497 tests pass, `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaBVS1zDC7QQumo8UyAWYT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaBVS1zDC7QQumo8UyAWYT)_