### PR TITLE
chore(deps): refresh stale KG adapter floors, drop lancedb from kgrag[kg]

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -322,12 +322,12 @@ version = "3.0.1"
 description = "Annotate AST trees with source code positions"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a"},
     {file = "asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [package.extras]
 astroid = ["astroid (>=2,<5)"]
@@ -1375,12 +1375,12 @@ version = "5.3.1"
 description = "Decorators for Humans"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c"},
     {file = "decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [[package]]
 name = "defusedxml"
@@ -1393,22 +1393,6 @@ files = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
-
-[[package]]
-name = "deprecation"
-version = "2.1.0"
-description = "A library to handle automated deprecations"
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"},
-    {file = "deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"},
-]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
-
-[package.dependencies]
-packaging = "*"
 
 [[package]]
 name = "detect-secrets"
@@ -1432,23 +1416,22 @@ word-list = ["pyahocorasick"]
 
 [[package]]
 name = "diary-kg"
-version = "0.93.2"
+version = "0.96.0"
 description = "A knowledge graph builder and semantic search engine for diaries and journals"
 optional = true
 python-versions = "<3.14,>=3.12"
 groups = ["main"]
 markers = "extra == \"kg\" or extra == \"all\""
 files = [
-    {file = "diary_kg-0.93.2-py3-none-any.whl", hash = "sha256:0de92c7a202ef84dff2c510109c5e0cd5f3eb501892d04649efae34f05ab9272"},
-    {file = "diary_kg-0.93.2.tar.gz", hash = "sha256:14b846e46b863075b1697580283b346030440df4f2873ce455c4934eb2b9c30c"},
+    {file = "diary_kg-0.96.0-py3-none-any.whl", hash = "sha256:ea213e23c412ae3eaf1446011fe949cc0e21b3dfafbfe35744b252b5dac1eb65"},
+    {file = "diary_kg-0.96.0.tar.gz", hash = "sha256:a2d4e05eaa747a10a58919eea621ddb69c7ae1752b3390ed8c93735710662f5d"},
 ]
 
 [package.dependencies]
 click = ">=8.1.0,<9"
-doc-kg = ">=0.15.8"
-kgmodule-utils = ">=0.4.0"
-lancedb = ">=0.29.0"
-mcp = ">=1.0.0"
+doc-kg = ">=0.20.0"
+kgmodule-utils = ">=0.9.0"
+mcp = ">=1.0.0,<2"
 numpy = ">=1.24.0"
 pandas = ">=2.0.0"
 rich = ">=14.3.3,<15"
@@ -1456,10 +1439,10 @@ sentence-transformers = ">=5.4.1"
 spacy = ">=3.8.11,<4"
 
 [package.extras]
-all = ["PyQt5 (>=5.15.0)", "detect-secrets (>=1.5.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pdoc (>=14.0.0)", "plotly (>=5.14.0)", "pre-commit (>=4.5.1)", "pycode-kg (>=0.19.0)", "pylint (>=4.0.5)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "pyvis (>=0.3.2)", "pyvista[jupyter] (>=0.44.0)", "pyvistaqt (>=0.11.0)", "ruff (>=0.4.0)", "streamlit (>=1.35.0)", "trame-vtk (>=2.0.0)", "ty (>=0.0.44)"]
-kgdeps = ["pycode-kg (>=0.19.0)"]
+all = ["PyQt5 (>=5.15.0)", "detect-secrets (>=1.5.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pdoc (>=14.0.0)", "pillow (>=10.0.0)", "plotly (>=5.14.0)", "pre-commit (>=4.5.1)", "pylint (>=4.0.5)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "pyvis (>=0.3.2)", "pyvista (>=0.44.0)", "pyvistaqt (>=0.11.0)", "ruff (>=0.4.0)", "streamlit (>=1.35.0)", "trame-vtk (>=2.0.0)", "ty (>=0.0.44)", "vtracer (>=0.6.15)"]
+dev = ["detect-secrets (>=1.5.0)", "pdoc (>=14.0.0)", "pillow (>=10.0.0)", "pre-commit (>=4.5.1)", "pylint (>=4.0.5)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "ruff (>=0.4.0)", "ty (>=0.0.44)", "vtracer (>=0.6.15)"]
 viz = ["plotly (>=5.14.0)", "pyvis (>=0.3.2)", "streamlit (>=1.35.0)"]
-viz3d = ["PyQt5 (>=5.15.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pyvista[jupyter] (>=0.44.0)", "pyvistaqt (>=0.11.0)", "trame-vtk (>=2.0.0)"]
+viz3d = ["PyQt5 (>=5.15.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pyvista (>=0.44.0)", "pyvistaqt (>=0.11.0)", "trame-vtk (>=2.0.0)"]
 
 [[package]]
 name = "diskcache"
@@ -1488,37 +1471,31 @@ files = [
 
 [[package]]
 name = "doc-kg"
-version = "0.19.1"
+version = "0.21.0"
 description = "A tool to build a semantically searchable knowledge graph from markdown and text documents"
 optional = false
 python-versions = "<3.14,>=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "doc_kg-0.19.1-py3-none-any.whl", hash = "sha256:9ec89dfd8ee1be3ac9cc7c646bbbf6195e25d4cec35fdfc57223e699468dc3c1"},
-    {file = "doc_kg-0.19.1.tar.gz", hash = "sha256:f2ed91ad898efcbd48f69ea72d7ef09356dbe84dd12ce8c22d3465308b98af8b"},
+    {file = "doc_kg-0.21.0-py3-none-any.whl", hash = "sha256:5198a82a4005e7bdaa424f82c0c79a96d94747acd11b9ac72ebe7feeec0b3e20"},
+    {file = "doc_kg-0.21.0.tar.gz", hash = "sha256:231fd5939dbc75f69241e5659f1796e12b0945e619bf41931274b0960aa21611"},
 ]
 markers = {main = "extra == \"kg\" or extra == \"all\""}
 
 [package.dependencies]
 click = ">=8.1.0,<9"
-einops = ">=0.8.2"
-kgmodule-utils = ">=0.9.0"
-lancedb = ">=0.29.0"
-markdown-it-py = ">=3.0.0"
+kgmodule-utils = {version = ">=0.10.0", extras = ["semantic"]}
 mcp = ">=1.0.0,<2"
-numpy = ">=1.24.0"
-pandas = ">=2.0.0"
 pymupdf4llm = ">=0.0.17"
 pyyaml = ">=6.0.0"
-rich = ">=13.0.0,<15.0.0"
-sentence-transformers = ">=5.4.1"
-transformers = ">=5.5.0,<6"
+rich = ">=14.3.3,<15"
+tqdm = ">=4.60"
 
 [package.extras]
-all = ["detect-secrets (>=1.5.0)", "pdoc (>=14.0.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "pyvis (>=0.3.2)", "ruff (>=0.4.0)", "scikit-learn (>=1.3.0)", "streamlit (>=1.35.0)", "ty (>=0.0.41)"]
-analysis = ["scikit-learn (>=1.3.0)"]
+all = ["detect-secrets (>=1.5.0)", "joblib (>=1.4.0)", "pdoc (>=14.0.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "pyvis (>=0.3.2)", "ruff (>=0.4.0)", "scikit-learn (>=1.3.0)", "streamlit (>=1.35.0)", "ty (>=0.0.41)"]
+analysis = ["joblib (>=1.4.0)", "scikit-learn (>=1.3.0)"]
 dev = ["detect-secrets (>=1.5.0)", "pdoc (>=14.0.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "ruff (>=0.4.0)", "ty (>=0.0.41)"]
-sqlite-vec = ["sqlite-vec (==0.1.9)"]
+lancedb = ["lancedb (>=0.29.0)"]
 viz = ["pyvis (>=0.3.2)", "streamlit (>=1.35.0)"]
 
 [[package]]
@@ -1540,30 +1517,17 @@ docs = ["pydoctor (>=25.4.0)"]
 test = ["pytest"]
 
 [[package]]
-name = "einops"
-version = "0.8.2"
-description = "A new flavour of deep learning operations"
-optional = false
-python-versions = ">=3.9"
-groups = ["main", "dev"]
-files = [
-    {file = "einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193"},
-    {file = "einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827"},
-]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
-
-[[package]]
 name = "executing"
 version = "2.2.1"
 description = "Get the currently executing AST node of a frame, and other information"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017"},
     {file = "executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [package.extras]
 tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich ; python_version >= \"3.11\""]
@@ -2189,12 +2153,12 @@ version = "9.14.1"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.11"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "ipython-9.14.1-py3-none-any.whl", hash = "sha256:5d4a9ecaa3b10e6e5f269dd0948bdb58ca9cb851899cd23e07c320d3eb11613c"},
     {file = "ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [package.dependencies]
 colorama = {version = ">=0.4.4", markers = "sys_platform == \"win32\""}
@@ -2223,12 +2187,12 @@ version = "1.1.1"
 description = "Defines a variety of Pygments lexers for highlighting IPython code."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c"},
     {file = "ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [package.dependencies]
 pygments = "*"
@@ -2290,12 +2254,12 @@ version = "0.20.0"
 description = "An autocompletion tool for Python that can be used for text editors."
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67"},
     {file = "jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [package.dependencies]
 parso = ">=0.8.6,<0.9.0"
@@ -2338,14 +2302,14 @@ files = [
 name = "jsonpickle"
 version = "4.1.2"
 description = "jsonpickle encodes/decodes any Python object to/from JSON"
-optional = false
+optional = true
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
+markers = "extra == \"viz\" or extra == \"all\""
 files = [
     {file = "jsonpickle-4.1.2-py3-none-any.whl", hash = "sha256:7ffe34426bc797684dbf1dc84185558bd864cd25b1ff5fb01b7405e392d0a937"},
     {file = "jsonpickle-4.1.2.tar.gz", hash = "sha256:8afed18aa189fd81e2e833b426bb4af485594921f0b1d36c2001fc5637a2f210"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\""}
 
 [package.extras]
 cov = ["pytest-cov"]
@@ -2594,28 +2558,27 @@ markers = {main = "extra == \"viz3d\" or extra == \"all\""}
 
 [[package]]
 name = "kgmodule-utils"
-version = "0.9.0"
+version = "0.10.0"
 description = "Shared types, graph store, semantic index, and pipeline base for the KGModule SDK"
 optional = false
 python-versions = "<3.14,>=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "kgmodule_utils-0.9.0-py3-none-any.whl", hash = "sha256:7f32869af0a8b6028314b84d3c00415ea85f0b66dc3207d8cad17e231cdcadf5"},
-    {file = "kgmodule_utils-0.9.0.tar.gz", hash = "sha256:7fa21007dd70ff0f019863ea6536c957c2973d47448aa07e4c459f6cc9c187c1"},
+    {file = "kgmodule_utils-0.10.0-py3-none-any.whl", hash = "sha256:765279f44cf754cf9256ddeab0eee4bb462f1028af3417eb321f7ef3ad1aa8a0"},
+    {file = "kgmodule_utils-0.10.0.tar.gz", hash = "sha256:b06a36c4674d2c308a776c6246f0519d99804fbd32e1901cd02fa240449baf24"},
 ]
 
 [package.dependencies]
-lancedb = {version = ">=0.19.0", optional = true, markers = "extra == \"semantic\""}
 numpy = {version = ">=1.24.0", optional = true, markers = "extra == \"semantic\""}
-pyvis = {version = ">=0.3.2", optional = true, markers = "extra == \"viz\""}
-rich = {version = ">=13.0.0", optional = true, markers = "extra == \"semantic\""}
+rich = {version = ">=13.0.0,<15.0.0", optional = true, markers = "extra == \"semantic\""}
 sentence-transformers = {version = ">=5.4.1", optional = true, markers = "extra == \"semantic\""}
 sqlite-vec = {version = "0.1.9", optional = true, markers = "extra == \"semantic\" or extra == \"sqlite-vec\""}
 torch = {version = ">=2.5.1", optional = true, markers = "extra == \"semantic\""}
 transformers = {version = ">=5.5.0,<6", optional = true, markers = "extra == \"semantic\""}
 
 [package.extras]
-semantic = ["lancedb (>=0.19.0)", "numpy (>=1.24.0)", "rich (>=13.0.0)", "sentence-transformers (>=5.4.1)", "sqlite-vec (==0.1.9)", "torch (>=2.5.1)", "transformers (>=5.5.0,<6)"]
+lancedb = ["lancedb (>=0.19.0)"]
+semantic = ["numpy (>=1.24.0)", "rich (>=13.0.0,<15.0.0)", "sentence-transformers (>=5.4.1)", "sqlite-vec (==0.1.9)", "torch (>=2.5.1)", "transformers (>=5.5.0,<6)"]
 sqlite-vec = ["sqlite-vec (==0.1.9)"]
 synthesis = ["httpx (>=0.27.0)", "openai (>=1.30.0)", "pillow (>=10.0.0)"]
 synthesis-mflux = ["httpx (>=0.27.0)", "mflux (>=0.9.0)", "openai (>=1.30.0)", "pillow (>=10.0.0)"]
@@ -2748,77 +2711,6 @@ files = [
     {file = "kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a"},
 ]
 markers = {main = "extra == \"viz3d\" or extra == \"all\""}
-
-[[package]]
-name = "lance-namespace"
-version = "0.8.2"
-description = "Lance Namespace interface and plugin registry"
-optional = false
-python-versions = ">=3.8"
-groups = ["main", "dev"]
-files = [
-    {file = "lance_namespace-0.8.2-py3-none-any.whl", hash = "sha256:6531a4d8b95f201835b954a949f890d03cbc3124aca5f1dd21d999157a08935f"},
-    {file = "lance_namespace-0.8.2.tar.gz", hash = "sha256:78cd6ad2f2764bccded1d8b64474419cc5571956b68a23ad2770977ddaeb03a1"},
-]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
-
-[package.dependencies]
-lance-namespace-urllib3-client = "0.8.2"
-
-[[package]]
-name = "lance-namespace-urllib3-client"
-version = "0.8.2"
-description = "Lance Namespace Specification"
-optional = false
-python-versions = ">=3.8"
-groups = ["main", "dev"]
-files = [
-    {file = "lance_namespace_urllib3_client-0.8.2-py3-none-any.whl", hash = "sha256:cb8dc098fcd42f848eb5206fb49ebc3b5f162ee32b5c4155a5048ffd30a7cd37"},
-    {file = "lance_namespace_urllib3_client-0.8.2.tar.gz", hash = "sha256:82f0a5c9b6b7fde67326d6038b89ed807e8d14692e461246f1a7df5c36b804d6"},
-]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
-
-[package.dependencies]
-pydantic = ">=2"
-python-dateutil = ">=2.8.2"
-typing-extensions = ">=4.7.1"
-urllib3 = ">=1.25.3,<3.0.0"
-
-[[package]]
-name = "lancedb"
-version = "0.33.0"
-description = "lancedb"
-optional = false
-python-versions = ">=3.10"
-groups = ["main", "dev"]
-files = [
-    {file = "lancedb-0.33.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d4eaf6fa7c2eac619208f1d396f4de635ee0f535673067118a31c1181575c48b"},
-    {file = "lancedb-0.33.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c6c2402ed2744245ae76c4167c0461da0a7a80f1608e0ec491c1548ea2b4302"},
-    {file = "lancedb-0.33.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ebf1ffad811e6254a93931a79489ba1f21f48564bdfa06abae846f5fcaaf3e8"},
-    {file = "lancedb-0.33.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:13da39f80adfea59e5831fe64e4166b2d70a2f843e6507bf644c4fe4c350087c"},
-    {file = "lancedb-0.33.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:21b712825f0a00225e8974a41352c4ea84b0899ef8c23b17f672fadc38bd8346"},
-    {file = "lancedb-0.33.0-cp39-abi3-win_amd64.whl", hash = "sha256:4ba78c6202b0f6c2ce8edc7aa470e550d2da56271c7cbdd10428613f1f7126f9"},
-]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
-
-[package.dependencies]
-deprecation = ">=2.1.0"
-lance-namespace = ">=0.3.2"
-numpy = ">=1.24.0"
-packaging = ">=23.0"
-pyarrow = ">=16"
-pydantic = ">=1.10"
-tqdm = ">=4.27.0"
-
-[package.extras]
-azure = ["adlfs (>=2024.2.0)"]
-clip = ["open-clip-torch", "pillow (>=12.1.1)", "torch"]
-dev = ["pre-commit (>=3.5.0)", "pyright (>=1.1.350)", "ruff (>=0.3.0)", "typing-extensions (>=4.0.0) ; python_full_version < \"3.11.0\""]
-docs = ["mkdocs", "mkdocs-jupyter", "mkdocs-material", "mkdocstrings-python"]
-embeddings = ["awscli (>=1.44.38)", "boto3 (>=1.28.57)", "botocore (>=1.31.57)", "cohere (>=4.0)", "colpali-engine (>=0.3.10)", "google-genai (>=1.0.0)", "huggingface-hub (>=0.19.0)", "ibm-watsonx-ai (>=1.1.2) ; python_full_version >= \"3.10.0\"", "instructorembedding (>=1.0.1)", "ollama (>=0.3.0)", "open-clip-torch (>=2.20.0)", "openai (>=1.6.1)", "pillow (>=12.1.1)", "requests (>=2.31.0)", "sentence-transformers (>=2.2.0)", "sentencepiece (>=0.1.99)", "torch (>=2.0.0)"]
-pylance = ["pylance (>=5.0.0b5)"]
-siglip = ["pillow (>=12.1.1)", "sentencepiece", "torch", "transformers (>=4.41.0)"]
-tests = ["aiohttp (>=3.9.0)", "boto3 (>=1.28.57)", "datafusion (>=52,<53)", "duckdb (>=0.9.0)", "pandas (>=1.4)", "polars (>=0.19,<=1.3.0)", "pyarrow-stubs (>=16.0)", "pylance (>=5.0.0b5)", "pytest (>=7.0)", "pytest-asyncio (>=0.21)", "pytest-mock (>=3.10)", "pytz (>=2023.3)", "requests (>=2.31.0)"]
 
 [[package]]
 name = "lark"
@@ -3124,12 +3016,12 @@ version = "0.2.2"
 description = "Inline Matplotlib backend for Jupyter"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6"},
     {file = "matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [package.dependencies]
 traitlets = "*"
@@ -4196,12 +4088,12 @@ version = "0.8.7"
 description = "A Python Parser"
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c"},
     {file = "parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [package.extras]
 qa = ["flake8 (==5.0.4)", "types-setuptools (==67.2.0.1)", "zuban (==0.5.1)"]
@@ -4231,12 +4123,12 @@ version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
 optional = false
 python-versions = "*"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
     {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
 ]
-markers = {main = "(extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\") and sys_platform != \"win32\" and sys_platform != \"emscripten\"", dev = "sys_platform != \"win32\" and sys_platform != \"emscripten\"", viz3d = "sys_platform != \"win32\" and sys_platform != \"emscripten\""}
+markers = {main = "(extra == \"viz\" or extra == \"all\" or extra == \"viz3d\") and sys_platform != \"win32\" and sys_platform != \"emscripten\"", viz3d = "sys_platform != \"win32\" and sys_platform != \"emscripten\""}
 
 [package.dependencies]
 ptyprocess = ">=0.5"
@@ -4622,12 +4514,12 @@ version = "3.0.52"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
     {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [package.dependencies]
 wcwidth = "*"
@@ -4789,7 +4681,7 @@ version = "7.2.2"
 description = "Cross-platform lib for process and system monitoring."
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b"},
     {file = "psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea"},
@@ -4813,7 +4705,7 @@ files = [
     {file = "psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee"},
     {file = "psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"},
 ]
-markers = {main = "(extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\") and sys_platform != \"emscripten\"", dev = "sys_platform != \"emscripten\"", viz3d = "sys_platform != \"emscripten\""}
+markers = {main = "(extra == \"viz\" or extra == \"all\" or extra == \"viz3d\") and sys_platform != \"emscripten\"", viz3d = "sys_platform != \"emscripten\""}
 
 [package.extras]
 dev = ["abi3audit", "black", "check-manifest", "colorama ; os_name == \"nt\"", "coverage", "packaging", "psleak", "pylint", "pyperf", "pypinfo", "pyreadline3 ; os_name == \"nt\"", "pytest", "pytest-cov", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "validate-pyproject[all]", "virtualenv", "vulture", "wheel", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
@@ -4825,12 +4717,12 @@ version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
 optional = false
 python-versions = "*"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
 ]
-markers = {main = "(extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\") and sys_platform != \"win32\" and sys_platform != \"emscripten\" or os_name != \"nt\"", dev = "sys_platform != \"win32\" and sys_platform != \"emscripten\"", viz3d = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or os_name != \"nt\""}
+markers = {main = "(extra == \"viz\" or extra == \"all\" or extra == \"viz3d\") and sys_platform != \"win32\" and sys_platform != \"emscripten\" or os_name != \"nt\"", viz3d = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or os_name != \"nt\""}
 
 [[package]]
 name = "pure-eval"
@@ -4838,12 +4730,12 @@ version = "0.2.3"
 description = "Safely evaluate AST nodes without side effects"
 optional = false
 python-versions = "*"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
     {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [package.extras]
 tests = ["pytest"]
@@ -4867,9 +4759,10 @@ defusedxml = ">=0.7.1,<0.8.0"
 name = "pyarrow"
 version = "24.0.0"
 description = "Python library for Apache Arrow"
-optional = false
+optional = true
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main"]
+markers = "extra == \"viz\" or extra == \"all\""
 files = [
     {file = "pyarrow-24.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:7c2b98645d576a0b9616892ead22b64a83a5f043c5e2ca15ebcefcb5b70c80cb"},
     {file = "pyarrow-24.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:644a246325b8c69c595ad1dd4b463eba4b0cdb731370e4a86137d433208d6147"},
@@ -4922,39 +4815,37 @@ files = [
     {file = "pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19"},
     {file = "pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\""}
 
 [[package]]
 name = "pycode-kg"
-version = "0.21.1"
+version = "0.21.4"
 description = "A tool to build a searchable knowledge graph from Python repositories"
 optional = false
 python-versions = "<3.14,>=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "pycode_kg-0.21.1-py3-none-any.whl", hash = "sha256:3093460f0ce6af9dbc7eb8a9e1d929032593b36a6e2e3a9cff850be4a162f1a7"},
-    {file = "pycode_kg-0.21.1.tar.gz", hash = "sha256:bc56bee83041a9f0563d7e07d6e342168b2ba210e09f5099be1bb9f6f5730833"},
+    {file = "pycode_kg-0.21.4-py3-none-any.whl", hash = "sha256:bcca9ed8e4c276d513af8da7b0726e8ba2cd36e8f18632a4f1940ad710a9e0f0"},
+    {file = "pycode_kg-0.21.4.tar.gz", hash = "sha256:2a94e9dd62d1c745f27ea371c03a8e69275992ebf7e6dcd1faf29cd042f73150"},
 ]
 markers = {main = "extra == \"kg\" or extra == \"all\""}
 
 [package.dependencies]
 click = ">=8.1.0,<9"
-kgmodule-utils = {version = ">=0.9.0", extras = ["semantic", "sqlite-vec", "viz"]}
+kgmodule-utils = {version = ">=0.10.0", extras = ["semantic"]}
 mcp = ">=1.0.0,<2"
 networkx = ">=3.0"
 numpy = ">=1.24.0"
 pandas = ">=2.0.0"
 rich = ">=14.3.3,<15"
-safetensors = ">=0.5.0"
 sentence-transformers = ">=5.4.1"
+sqlite-vec = "0.1.9"
 torch = ">=2.5.1"
-transformers = ">=5.5.0,<6"
 
 [package.extras]
-all = ["PyQt5 (>=5.15.0)", "detect-secrets (>=1.5.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pdoc (>=14.0.0)", "plotly (>=5.14.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "pyvis (>=0.3.2)", "pyvista[jupyter] (>=0.44.0)", "pyvistaqt (>=0.11.0)", "ruff (>=0.4.0)", "streamlit (>=1.56.0)", "trame-vtk (>=2.0.0)", "ty (>=0.0.41)"]
+all = ["PyQt5 (>=5.15.0)", "detect-secrets (>=1.5.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pdoc (>=14.0.0)", "plotly (>=5.14.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "pyvis (>=0.3.2)", "pyvista (>=0.44.0)", "pyvistaqt (>=0.11.0)", "ruff (>=0.4.0)", "streamlit (>=1.56.0)", "trame-vtk (>=2.0.0)", "ty (>=0.0.41)"]
 dev = ["detect-secrets (>=1.5.0)", "pdoc (>=14.0.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "ruff (>=0.4.0)", "ty (>=0.0.41)"]
 viz = ["plotly (>=5.14.0)", "pyvis (>=0.3.2)", "streamlit (>=1.56.0)"]
-viz3d = ["PyQt5 (>=5.15.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pyvista[jupyter] (>=0.44.0)", "pyvistaqt (>=0.11.0)", "trame-vtk (>=2.0.0)"]
+viz3d = ["PyQt5 (>=5.15.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pyvista (>=0.44.0)", "pyvistaqt (>=0.11.0)", "trame-vtk (>=2.0.0)"]
 
 [[package]]
 name = "pycparser"
@@ -5474,13 +5365,13 @@ files = [
 name = "pyvis"
 version = "0.3.2"
 description = "A Python network graph visualization library"
-optional = false
+optional = true
 python-versions = ">3.6"
-groups = ["main", "dev"]
+groups = ["main"]
+markers = "extra == \"viz\" or extra == \"all\""
 files = [
     {file = "pyvis-0.3.2-py3-none-any.whl", hash = "sha256:5720c4ca8161dc5d9ab352015723abb7a8bb8fb443edeb07f7a322db34a97555"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\""}
 
 [package.dependencies]
 ipython = ">=5.3.0"
@@ -6820,12 +6711,12 @@ version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
 optional = false
 python-versions = "*"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
     {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [package.dependencies]
 asttokens = ">=2.1.0"
@@ -7328,7 +7219,7 @@ version = "5.15.1"
 description = "Traitlets Python configuration system"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92"},
     {file = "traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722"},
@@ -7815,12 +7706,12 @@ version = "0.8.1"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "viz3d"]
+groups = ["main", "viz3d"]
 files = [
     {file = "wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8"},
     {file = "wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"viz3d\""}
+markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\""}
 
 [[package]]
 name = "weasel"
@@ -8227,4 +8118,4 @@ viz3d = ["PyQt5", "markdown", "param", "pyvista", "pyvistaqt", "trame-vtk"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.14"
-content-hash = "87dfbf2674a4113ae01da147c371e994b7ec26ba4d6e762df7acacabc7e9afa2"
+content-hash = "c153fb449d38d3af08c5eaa5565c38bb8fd6213749384d532aa2459ce3621589"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,10 @@ python = ">=3.12,<3.14"
 # modules, which declare their own; KGRAG only passes paths through and, in
 # `kgrag audit-lancedb`, looks for leftover directories on disk. Health checks
 # shell out to each module's CLI for the same reason (see cmd_health).
-# doc-kg still hard-requires lancedb, so `kgrag[kg]` installs it transitively —
-# but a core KGRAG install no longer drags in a native store it never calls.
+# As of the doc-kg >=0.21.0 floor below, `kgrag[kg]` no longer drags lancedb in
+# transitively either: doc-kg moved it to an opt-in `[lancedb]` extra needed
+# only to read a pre-0.20.0 store. `kgrag audit-lancedb` is unaffected — it only
+# looks for leftover directories on disk and never imports the package.
 numpy = ">=1.24.0"
 # personal agent
 
@@ -126,11 +128,11 @@ llama-cpp-python = { version = ">=0.3.0", optional = true }
 
 
 # our own adaptors (PyPI-only; git-only adapters installed separately via uv)
-kgmodule-utils = ">=0.8.0"
-pycode-kg = {version = ">=0.20.0", optional=true}
-doc-kg = {version = ">=0.18.2", optional=true}
+kgmodule-utils = ">=0.10.0"
+pycode-kg = {version = ">=0.21.4", optional=true}
+doc-kg = {version = ">=0.21.0", optional=true}
 ftree-kg = {version = ">=0.9.0", optional=true}
-diary-kg  = {version = ">=0.93.2", optional = true}
+diary-kg  = {version = ">=0.96.0", optional = true}
 jupyter-server = ">=2.18.0"
 mistune = ">=3.2.1"
 
@@ -182,8 +184,8 @@ pip-audit = "^2.10.0"
 # right arguments, and a mocked-out import cannot show that it does. Installed
 # here so the suite exercises the real classes. The marginal cost is small —
 # sentence-transformers already pulls the torch/transformers stack.
-pycode-kg = ">=0.20.0"
-doc-kg = ">=0.18.2"
+pycode-kg = ">=0.21.4"
+doc-kg = ">=0.21.0"
 
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Every KG adapter floor here had drifted several releases behind PyPI, letting a resolver install old siblings with materially different behaviour.

| Package | Was | Now |
|---|---|---|
| `kgmodule-utils` | `>=0.8.0` | `>=0.10.0` |
| `pycode-kg` | `>=0.20.0` | `>=0.21.4` |
| `doc-kg` | `>=0.18.2` | `>=0.21.0` |
| `diary-kg` | `>=0.93.2` | `>=0.96.0` |

(`pycode-kg` and `doc-kg` appear twice each — the `[tool.poetry.dependencies]` extras entry and the dev group.)

### The diary-kg bump changes an install, not just a number

The comment above these pins claims a KGRAG install does not drag in lancedb. That was true of the **core** install — but `kgrag[kg]` was still pulling it transitively, because **diary-kg 0.93.2 hard-requires `lancedb>=0.29.0`**.

doc-kg had already moved lancedb to an opt-in `[lancedb]` extra in 0.20.0, and diary-kg followed suit by 0.96.0. With these floors, **`lancedb` is now absent from the lock file entirely**.

The comment is updated to say what is actually true, and to note that `kgrag audit-lancedb` is unaffected either way — it looks for leftover directories on disk and never imports the package.

### pandas

doc-kg 0.21.0 drops `pandas` from its core dependency set. **No impact here** — pandas is declared directly in `[tool.poetry.dependencies]`.

### Verification

`poetry.lock` regenerated in the same commit. The lock resolves doc-kg 0.21.0, pycode-kg 0.21.4, diary-kg 0.96.0 and kgmodule-utils 0.10.0, with no lancedb. Full suite passes (497 passed).

### Note for reviewers

The pre-commit `pytest` hook failed on the first commit attempt with `ModuleNotFoundError: No module named 'kg_rag'`. Pre-existing — the venv did not have the project installed. Fixed with `poetry install --only-root`. No hook was bypassed.

Part of a fleet-wide dependency-hygiene pass; companion PRs in metabo_kg, ia_kg and tscode_kg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
