### PR TITLE
ci: verify the built wheel, not just the source tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,62 @@ jobs:
 
       - name: Run tests
         run: poetry run pytest
+
+  wheel:
+    name: Installed CLI
+    runs-on: ubuntu-latest
+    # Guards the one thing the other jobs structurally cannot see. lint,
+    # type-check and test all run against the source tree with
+    # pythonpath = ["src"], so they pass even when the built wheel is missing
+    # modules the CLI imports, or when a dependency is declared in a form PyPI
+    # strips from wheel metadata. ia-kg 0.1.0 shipped exactly that way: green
+    # CI, and every console script dead on `pip install`.
+    #
+    # This builds the artifact users actually receive, installs it somewhere
+    # with no source tree in sight, and loads every console-script entry point.
+    # entry_point.load() imports the module and resolves the attribute without
+    # calling it -- so an MCP server entry point is verified, not started.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Build wheel
+        run: poetry build
+
+      - name: Install the wheel into a clean venv
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install --quiet dist/*.whl
+
+      - name: Load every console-script entry point
+        run: |
+          cd /tmp
+          /tmp/smoke/bin/python - <<'PY'
+          import importlib.metadata as md
+          import sys
+
+          eps = [e for e in md.distribution("kg-rag").entry_points
+                 if e.group == "console_scripts"]
+          if not eps:
+              sys.exit("no console scripts found in the installed distribution")
+
+          failed = []
+          for e in sorted(eps, key=lambda e: e.name):
+              try:
+                  e.load()
+                  print(f"  ok    {e.name} -> {e.value}")
+              except Exception as exc:
+                  failed.append(e.name)
+                  print(f"  FAIL  {e.name} -> {e.value}\n        {type(exc).__name__}: {exc}")
+          if failed:
+              sys.exit(f"\n{len(failed)} console script(s) unusable when installed: "
+                       + ", ".join(failed))
+          print(f"\nall {len(eps)} console scripts load from a clean install")
+          PY


### PR DESCRIPTION
Adds an **Installed CLI** job that builds the wheel, installs it into a clean virtualenv with no source tree in sight, and loads every console-script entry point.

### Why the existing jobs cannot catch this

`lint`, `type-check` and `test` all run against `src/` via `pythonpath = ["src"]`. That makes them structurally blind to a broken *artifact*: a module the CLI imports can be absent from the wheel, or a dependency can be declared in a form PyPI strips from wheel metadata, and every existing job still goes green.

Not hypothetical — **ia-kg 0.1.0 shipped to PyPI with green CI and a console script that died on import**:

```
ModuleNotFoundError: No module named 'download_ia'
```

1,588 lines of its implementation lived in `scripts/`, which the wheel does not ship, reached by a `sys.path` hack walking four parents up from `__file__` — correct from a clone, meaningless from `site-packages`. A second defect in the same package declared `kg-rag` as a poetry git source, which PyPI strips, so `iakg ingest` died on a missing `kg_rag`. Neither is visible without installing the artifact.

### Scope

A static audit of the fleet found **no other published package broken this way**, so this job is preventive here rather than a fix. It is cheap and cannot go stale.

### How it checks

`entry_point.load()` imports the module and resolves the attribute **without calling it**. That is deliberate:

- an MCP server entry point is *verified*, not *started* — the job cannot hang
- no per-repo list of commands or arguments to maintain
- entry points come from installed metadata, so new console scripts are covered automatically

### Validated against the real failure before rollout

| Package | Result |
|---|---|
| ia-kg 0.1.0 (broken) | **exit 1** — `1 console script(s) unusable when installed: iakg` |
| ia-kg 0.1.1 (fixed) | exit 0 |
| diary-kg 0.96.0 | exit 0 — 4 scripts incl. an MCP server |
| ftree-kg 0.10.1 | exit 0 — 6 scripts |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
