### PR TITLE
docs: SISTER_PROJECTS.md — the KGRAG family in one page

### DIFF
--- a/docs/SISTER_PROJECTS.md
+++ b/docs/SISTER_PROJECTS.md
@@ -1,0 +1,47 @@
+# The KGRAG family
+
+KGRAG federates a family of knowledge-graph systems that share one design:
+a local SQLite graph of typed relationships, a sqlite-vec index beside it for
+natural-language entry, and structure treated as ground truth when the two
+disagree. Each applies it to a different kind of corpus.
+
+Because they share that shape, one KGRAG query can span all of them.
+
+## The graphs
+
+Most are installable from PyPI. GutenbergKG and MetaboKG are applications
+over a corpus rather than libraries, so they are not packaged — clone and
+run them from source.
+
+| Project | Corpus | PyPI |
+|---|---|---|
+| **[GutenbergKG](https://github.com/Flux-Frontiers/gutenberg_kg)** | Project Gutenberg texts: books as documents, sections, and chunks | not a package |
+| **[DocKG](https://github.com/Flux-Frontiers/doc_kg)** | Markdown and prose. any Markdown or prose corpus becomes a queryable graph | `doc-kg` |
+| **[DiaryKG](https://github.com/Flux-Frontiers/diary_kg)** | Personal journals and diary corpora — semantic search and traversal over a writer's body of work | `diary-kg` |
+| **[AgentKG](https://github.com/Flux-Frontiers/agent_kg)** | Conversational memory: turns, decisions, commitments, preferences, and the relationships between them | `agent-kg` |
+| **[FTreeKG](https://github.com/Flux-Frontiers/ftree_kg)** | Filesystem trees as a graph of directories, files, and contents | `ftree-kg` |
+| **[IAKG](https://github.com/Flux-Frontiers/ia_kg)** | Internet Archive books, downloaded and ingested as graphs | `ia-kg` |
+| **[MemoryKG](https://github.com/Flux-Frontiers/memory_kg)** | Long-term agent memory as a graph | `memory-kg` |
+| **[MetaboKG](https://github.com/Flux-Frontiers/metabo_kg)** | Metabolic pathway data (KEGG, SBML, BioPAX), with FBA / ODE simulation on top of the graph | not a package |
+| **[PyCodeKG](https://github.com/Flux-Frontiers/pycode_kg)** | Python codebases — modules, classes, functions, and the calls between them | `pycode-kg` |
+| **[TSCodeKG](https://github.com/Flux-Frontiers/tscode_kg)** | TypeScript and JavaScript codebases, the same treatment | `tscode-kg` |
+
+## The federation
+
+This repository (`kg-rag`) is the retrieval layer over the graphs above. One
+query reaches across code, documentation, journals, filesystems, agent memory,
+and domain data at once, with results ranked together rather than per-store.
+
+Per-repo version state — local vs. PyPI — is tracked separately in
+[FLEET_VERSIONS.md](FLEET_VERSIONS.md), which is generated; this page is the
+prose companion to it.
+
+## Shared foundations
+
+Two packages hold what is common, so no graph reimplements it:
+
+- **[kgmodule-utils](https://pypi.org/project/kgmodule-utils/)** — the store,
+  the semantic index, the ranking primitives, and the shared 3-D layout and
+  organic-growth engines.
+- **[quiltwright](https://pypi.org/project/quiltwright/)** — light-field output
+  for Looking Glass displays, used by any graph that wants a hologram.


### PR DESCRIPTION
KGRAG federates a family of graphs that share one design: a local SQLite graph
of typed relationships, a sqlite-vec index beside it for natural-language
entry, and structure treated as ground truth when the two disagree. That shared
shape is what makes one query able to span all of them, and it was written down
nowhere a reader would find it.

Tabulates each graph with its corpus and its PyPI name, and marks the two that
are applications over a corpus rather than libraries — GutenbergKG and MetaboKG
are cloned and run from source, not installed.

Mirrors the page `pycode_kg` added in 0.23.0, so the family reads the same from
whichever repo a reader arrives at.

### Note

Nothing links to this page yet; the README pointer is a follow-up.
`pycode_kg` linked its equivalent from the README in the same release.

### Provenance

This commit landed on `main` locally carrying a **recycled message** from a
months-old release (`chore(release): bump to 0.10.1; fix CodeKGAdapter for
pycode-kg 0.20.0`), describing a `CodeKGAdapter` fix, dependency floors and
`AGENTS.md`/`TODO.md` files it does not contain — in a repo at 0.12.0, not
0.10.1. It was never pushed, so the message was amended before it became
public. `git diff` between the original and amended commit is empty: only the
message changed.
