### PR TITLE
chore: bring dependency floors current, make the dev group optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           key: typecheck-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
-        run: poetry install --no-interaction
+        run: poetry install --no-interaction --with dev
 
       - name: Run ty
         run: poetry run ty check src/
@@ -94,7 +94,7 @@ jobs:
           key: test-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
-        run: poetry install --no-interaction
+        run: poetry install --no-interaction --with dev
 
       - name: Run tests
         run: poetry run pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.13
+    rev: v0.15.22
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1157,21 +1157,21 @@ word-list = ["pyahocorasick"]
 
 [[package]]
 name = "diary-kg"
-version = "0.96.0"
+version = "0.97.0"
 description = "A knowledge graph builder and semantic search engine for diaries and journals"
 optional = true
 python-versions = "<3.14,>=3.12"
 groups = ["main"]
 markers = "extra == \"kg\" or extra == \"all\""
 files = [
-    {file = "diary_kg-0.96.0-py3-none-any.whl", hash = "sha256:ea213e23c412ae3eaf1446011fe949cc0e21b3dfafbfe35744b252b5dac1eb65"},
-    {file = "diary_kg-0.96.0.tar.gz", hash = "sha256:a2d4e05eaa747a10a58919eea621ddb69c7ae1752b3390ed8c93735710662f5d"},
+    {file = "diary_kg-0.97.0-py3-none-any.whl", hash = "sha256:398bad39475e2423f8d5c48b76c32be21516fb7732b08ef605981c8e3132e700"},
+    {file = "diary_kg-0.97.0.tar.gz", hash = "sha256:f7712acaee94f8aaa449844dfe079e781cda2108b0a31d6281b52c9be6d2e00c"},
 ]
 
 [package.dependencies]
 click = ">=8.1.0,<9"
-doc-kg = ">=0.20.0"
-kgmodule-utils = ">=0.9.0"
+doc-kg = ">=0.21.2"
+kgmodule-utils = ">=0.13.2"
 mcp = ">=1.0.0,<2"
 numpy = ">=1.24.0"
 pandas = ">=2.0.0"
@@ -1180,8 +1180,6 @@ sentence-transformers = ">=5.4.1"
 spacy = ">=3.8.11,<4"
 
 [package.extras]
-all = ["PyQt5 (>=5.15.0)", "detect-secrets (>=1.5.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pdoc (>=14.0.0)", "pillow (>=10.0.0)", "plotly (>=5.14.0)", "pre-commit (>=4.5.1)", "pylint (>=4.0.5)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "pyvis (>=0.3.2)", "pyvista (>=0.44.0)", "pyvistaqt (>=0.11.0)", "ruff (>=0.4.0)", "streamlit (>=1.35.0)", "trame-vtk (>=2.0.0)", "ty (>=0.0.44)", "vtracer (>=0.6.15)"]
-dev = ["detect-secrets (>=1.5.0)", "pdoc (>=14.0.0)", "pillow (>=10.0.0)", "pre-commit (>=4.5.1)", "pylint (>=4.0.5)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "ruff (>=0.4.0)", "ty (>=0.0.44)", "vtracer (>=0.6.15)"]
 viz = ["plotly (>=5.14.0)", "pyvis (>=0.3.2)", "streamlit (>=1.35.0)"]
 viz3d = ["PyQt5 (>=5.15.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pyvista (>=0.44.0)", "pyvistaqt (>=0.11.0)", "trame-vtk (>=2.0.0)"]
 
@@ -1212,20 +1210,20 @@ files = [
 
 [[package]]
 name = "doc-kg"
-version = "0.21.1"
+version = "0.21.2"
 description = "A tool to build a semantically searchable knowledge graph from markdown and text documents"
 optional = false
 python-versions = "<3.14,>=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "doc_kg-0.21.1-py3-none-any.whl", hash = "sha256:1853b2b0a896c0997a60743566209f8065ba8f9c9c8ac8de2a5af3be235a1fc2"},
-    {file = "doc_kg-0.21.1.tar.gz", hash = "sha256:e806852c723bc278dbe648c14bc2b40a3f3240c879818bc4a3b521edeabb6614"},
+    {file = "doc_kg-0.21.2-py3-none-any.whl", hash = "sha256:56a9daca368d96c782b96bc5e238c3b1ea03ec84a35784b0e2c469badbe723f2"},
+    {file = "doc_kg-0.21.2.tar.gz", hash = "sha256:d02fa9b25b50512bf0fbbf574861cd28c6a8a82f0602528f8e8e212940dca363"},
 ]
 markers = {main = "extra == \"kg\" or extra == \"all\""}
 
 [package.dependencies]
 click = ">=8.1.0,<9"
-kgmodule-utils = {version = ">=0.10.0", extras = ["semantic"]}
+kgmodule-utils = {version = ">=0.12.1", extras = ["semantic"]}
 mcp = ">=1.0.0,<2"
 pymupdf4llm = ">=0.0.17"
 pyyaml = ">=6.0.0"
@@ -1233,9 +1231,9 @@ rich = ">=14.3.3,<15"
 tqdm = ">=4.60"
 
 [package.extras]
-all = ["detect-secrets (>=1.5.0)", "joblib (>=1.4.0)", "pdoc (>=14.0.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "pyvis (>=0.3.2)", "ruff (>=0.4.0)", "scikit-learn (>=1.3.0)", "streamlit (>=1.35.0)", "ty (>=0.0.41)"]
+all = ["detect-secrets (>=1.5.0)", "joblib (>=1.4.0)", "pdoc (>=14.0.0)", "pre-commit (>=4.5.1)", "pytest (>=9.0.3)", "pytest-cov (>=5.0.0)", "pyvis (>=0.3.2)", "ruff (>=0.4.0,<0.16)", "scikit-learn (>=1.3.0)", "streamlit (>=1.35.0)", "ty (>=0.0.41)"]
 analysis = ["joblib (>=1.4.0)", "scikit-learn (>=1.3.0)"]
-dev = ["detect-secrets (>=1.5.0)", "pdoc (>=14.0.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "ruff (>=0.4.0)", "ty (>=0.0.41)"]
+dev = ["detect-secrets (>=1.5.0)", "pdoc (>=14.0.0)", "pre-commit (>=4.5.1)", "pytest (>=9.0.3)", "pytest-cov (>=5.0.0)", "ruff (>=0.4.0,<0.16)", "ty (>=0.0.41)"]
 lancedb = ["lancedb (>=0.29.0)"]
 viz = ["pyvis (>=0.3.2)", "streamlit (>=1.35.0)"]
 
@@ -1847,14 +1845,14 @@ referencing = ">=0.31.0"
 
 [[package]]
 name = "kgmodule-utils"
-version = "0.13.0"
+version = "0.13.2"
 description = "Shared types, graph store, semantic index, and pipeline base for the KGModule SDK"
 optional = false
 python-versions = "<3.14,>=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "kgmodule_utils-0.13.0-py3-none-any.whl", hash = "sha256:6ef70d3a2f42acabe94fb3768b6b9a0281199ff0e0b667e50279354d411878b2"},
-    {file = "kgmodule_utils-0.13.0.tar.gz", hash = "sha256:d6eb38618af2eb6caf0d3e07fcce61e2447f5a2684400a8af1d8be12f674821c"},
+    {file = "kgmodule_utils-0.13.2-py3-none-any.whl", hash = "sha256:379f6a6f47ed3523375a53895fb310830272b6782e057492c4b2b089f5464890"},
+    {file = "kgmodule_utils-0.13.2.tar.gz", hash = "sha256:43d6797f7dec305ee841cd997f4ea0e55de7d04546e15ae6199865bbdf58ea86"},
 ]
 
 [package.dependencies]
@@ -3676,20 +3674,20 @@ files = [
 
 [[package]]
 name = "pycode-kg"
-version = "0.22.0"
+version = "0.23.1"
 description = "A tool to build a searchable knowledge graph from Python repositories"
 optional = false
 python-versions = "<3.14,>=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "pycode_kg-0.22.0-py3-none-any.whl", hash = "sha256:c164193b20116ab845fb9467e65e32b92fcc77922cab037b3afae2f2c5efbe0e"},
-    {file = "pycode_kg-0.22.0.tar.gz", hash = "sha256:631ad04fc9b5a750f09b7a2189b0be2855d1fcdcb8b4ab6c665e3d64f64af96f"},
+    {file = "pycode_kg-0.23.1-py3-none-any.whl", hash = "sha256:3904100f333a688aacbd1e637bf52dec9d3adaa3e79786cd8848f2203e305f1c"},
+    {file = "pycode_kg-0.23.1.tar.gz", hash = "sha256:b3896b9043d5b978239af2e7a5ecb09eb3cb8ee906b696fd8d7015050fde4926"},
 ]
 markers = {main = "extra == \"kg\" or extra == \"all\""}
 
 [package.dependencies]
 click = ">=8.1.0,<9"
-kgmodule-utils = {version = ">=0.11.0", extras = ["semantic", "viz3d"]}
+kgmodule-utils = {version = ">=0.13.1", extras = ["semantic", "viz3d"]}
 mcp = ">=1.0.0,<2"
 networkx = ">=3.0"
 numpy = ">=1.24.0"
@@ -3697,13 +3695,13 @@ pandas = ">=2.0.0"
 rich = ">=14.3.3,<15"
 sentence-transformers = ">=5.4.1"
 sqlite-vec = "0.1.9"
+starlette = ">=0.49.1,<1.4.0"
 torch = ">=2.5.1"
 
 [package.extras]
-all = ["PyQt5 (>=5.15.0)", "detect-secrets (>=1.5.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pdoc (>=14.0.0)", "plotly (>=5.14.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "pyvis (>=0.3.2)", "pyvista (>=0.44.0)", "pyvistaqt (>=0.11.0)", "ruff (>=0.4.0)", "streamlit (>=1.56.0)", "trame-vtk (>=2.0.0)", "ty (>=0.0.41)"]
-dev = ["detect-secrets (>=1.5.0)", "pdoc (>=14.0.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "ruff (>=0.4.0)", "ty (>=0.0.41)"]
+all = ["PyQt5 (>=5.15.0)", "markdown (>=3.6)", "param (>=2.0.0)", "plotly (>=5.14.0)", "pyvis (>=0.3.2)", "pyvista (>=0.44.0)", "pyvistaqt (>=0.11.0)", "quiltwright (>=0.4.0)", "streamlit (>=1.56.0)", "trame-vtk (>=2.0.0)"]
 viz = ["plotly (>=5.14.0)", "pyvis (>=0.3.2)", "streamlit (>=1.56.0)"]
-viz3d = ["PyQt5 (>=5.15.0)", "markdown (>=3.6)", "param (>=2.0.0)", "pyvista (>=0.44.0)", "pyvistaqt (>=0.11.0)", "trame-vtk (>=2.0.0)"]
+viz3d = ["PyQt5 (>=5.15.0)", "kgmodule-utils[viz3d-render] (>=0.12.1)", "markdown (>=3.6)", "param (>=2.0.0)", "pyvistaqt (>=0.11.0)", "quiltwright (>=0.4.0)", "trame-vtk (>=2.0.0)"]
 
 [[package]]
 name = "pycparser"
@@ -6387,4 +6385,4 @@ viz3d = ["PyQt5", "markdown", "param", "pyvista", "pyvistaqt", "trame-vtk"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.14"
-content-hash = "0fec0718618f2bbac144b929d276c220f644c88346d1bd04fdfb10d8a6b1d8d2"
+content-hash = "c98497ff6246e7cbb537b15c7f6295b2c3d8a709eb6fd16fb77c253fcdbc2eb5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@
 # perform code analysis, or build AI-powered development tools.
 #
 # Author: Eric G. Suchanek, PhD
-# Last Revision: 2026-07-29 16:45:00
 #
 # Quick install (poetry) — recommended
 # -------------------------------------
 #   poetry install                               core orchestrator only
+#   poetry install --with dev                    core + dev tools (the group is optional)
 #   poetry install --extras "kg"                 core + PyPI KG adapters (pycode-kg, doc-kg, ftree-kg, diary-kg)
 #   poetry install --extras "viz"                core + 2D visualization (streamlit, pyvis, plotly)
 #   poetry install --extras "viz3d"              core + 3D visualization (pyvista, pyvistaqt, PyQt5)
@@ -132,13 +132,16 @@ llama-cpp-python = { version = ">=0.3.0", optional = true }
 
 
 # our own adaptors (PyPI-only; git-only adapters installed separately via uv)
-# 0.13.0 is the floor because it ships TEIEmbedder, which `embed_backend =
-# "tei"` in src/kg_rag/embed.py imports directly.
-kgmodule-utils = ">=0.13.0"
-pycode-kg = {version = ">=0.22.0", optional=true}
-doc-kg = {version = ">=0.21.1", optional=true}
+# 0.13.0 was the original floor because it ships TEIEmbedder, which
+# `embed_backend = "tei"` in src/kg_rag/embed.py imports directly. 0.13.2 is
+# the floor now: 0.13.1 made SnapshotManager's `repo_root` a read-only property
+# and broke every subclass that assigns it, so nothing in the fleet declares a
+# floor that can resolve to it.
+kgmodule-utils = ">=0.13.2"
+pycode-kg = {version = ">=0.23.1", optional=true}
+doc-kg = {version = ">=0.21.2", optional=true}
 ftree-kg = {version = ">=0.11.0", optional=true}
-diary-kg  = {version = ">=0.96.0", optional = true}
+diary-kg  = {version = ">=0.97.0", optional = true}
 
 
 [tool.poetry.extras]
@@ -174,6 +177,9 @@ param = ">=2.0.0"
 markdown = ">=3.6"
 trame-vtk = ">=2.0.0"
 
+[tool.poetry.group.dev]
+optional = true
+
 [tool.poetry.group.dev.dependencies]
 pytest = ">=9.0.3"
 pytest-cov = ">=5.0.0"
@@ -197,8 +203,8 @@ pip-audit = "^2.10.0"
 # right arguments, and a mocked-out import cannot show that it does. Installed
 # here so the suite exercises the real classes. The marginal cost is small —
 # sentence-transformers already pulls the torch/transformers stack.
-pycode-kg = ">=0.22.0"
-doc-kg = ">=0.21.1"
+pycode-kg = ">=0.23.1"
+doc-kg = ">=0.21.2"
 
 
 [tool.poetry.scripts]

--- a/scripts/generate_wiki.py
+++ b/scripts/generate_wiki.py
@@ -12,7 +12,6 @@ Usage:
     python scripts/generate_wiki.py --repo Flux-Frontiers/code_kg
 
 Author: Eric G. Suchanek, PhD
-Last Revision: 2026-03-02 14:03:04
 """
 
 import argparse

--- a/src/kg_rag/adapters/_stub_adapter.py
+++ b/src/kg_rag/adapters/_stub_adapter.py
@@ -10,7 +10,6 @@ real library becomes available.  Until then, ``is_available()`` returns False
 and all query/pack/stats/analyze calls return safe empty results.
 
 Author: Eric G. Suchanek, PhD
-Last Revision: 2026-06-09 11:50:02
 License: Elastic 2.0
 """
 

--- a/src/kg_rag/adapters/agent_adapter.py
+++ b/src/kg_rag/adapters/agent_adapter.py
@@ -16,7 +16,6 @@ Storage layout (auto-created on first use)::
         userprofile.sqlite # global UserProfile (Preference, Expertise, etc.)
 
 Author: Eric G. Suchanek, PhD
-Last Revision: 2026-06-09 11:50:02
 License: Elastic 2.0
 """
 

--- a/src/kg_rag/adapters/diary_adapter.py
+++ b/src/kg_rag/adapters/diary_adapter.py
@@ -1,7 +1,6 @@
 """diary_adapter.py — KGAdapter for DiaryKG.
 
 Author: Eric G. Suchanek, PhD
-Last Revision: 2026-06-09 11:50:02
 License: Elastic 2.0
 """
 

--- a/src/kg_rag/adapters/gutenberg_adapter.py
+++ b/src/kg_rag/adapters/gutenberg_adapter.py
@@ -10,7 +10,6 @@ that delegate to ``gutenberg_kg.corpus``, covering the full genre collection
 rather than a single registered KG entry.
 
 Author: Eric G. Suchanek, PhD
-Last Revision: 2026-07-26
 License: Elastic 2.0
 """
 

--- a/src/kg_rag/adapters/metakg_adapter.py
+++ b/src/kg_rag/adapters/metakg_adapter.py
@@ -4,7 +4,6 @@ metakg_adapter.py
 Adapter wrapping the metabokg package.
 
 Author: Eric G. Suchanek, PhD
-Last Revision: 2026-06-09 11:50:02
 License: Elastic 2.0
 """
 

--- a/src/kg_rag/cli/cmd_health.py
+++ b/src/kg_rag/cli/cmd_health.py
@@ -15,7 +15,6 @@ Usage::
     kgrag health --json        # machine-readable JSON output
 
 Author: Eric G. Suchanek, PhD
-Last Revision: 2026-07-30 02:54:06
 License: Elastic 2.0
 """
 

--- a/src/kg_rag/cli/cmd_hooks.py
+++ b/src/kg_rag/cli/cmd_hooks.py
@@ -9,7 +9,6 @@ The KGRAG hook orchestrates snapshots for all registered KGs (PyCodeKG, DocKG,
 etc.) that live in the workspace, then runs quality checks.
 
   Author: Eric G. Suchanek, PhD
-  Last Revision: 2026-04-26
 """
 
 from __future__ import annotations

--- a/src/kg_rag/cli/cmd_query.py
+++ b/src/kg_rag/cli/cmd_query.py
@@ -4,7 +4,6 @@ cmd_query.py
 Cross-KG query and pack commands.
 
 Author: Eric G. Suchanek, PhD
-Last Revision: 2026-04-22 21:05:53
 License: Elastic 2.0
 """
 

--- a/src/kg_rag/cli/cmd_synthesize.py
+++ b/src/kg_rag/cli/cmd_synthesize.py
@@ -16,7 +16,6 @@ Usage::
     kgrag synthesize "entropy" --backend openai --openai-url http://myserver:8000/v1
 
     Author: Eric G. Suchanek, PhD
-    Last Revision: 2026-05-30
 
     License: Elastic 2.0
 """

--- a/src/kg_rag/embed.py
+++ b/src/kg_rag/embed.py
@@ -39,7 +39,6 @@ Or via environment variable:
     KG_EMBED_ENDPOINT=http://localhost:8080 kgrag query "..."   # with embed_backend = "tei"
 
 Author: Eric G. Suchanek, PhD
-Last Revision: 2026-04-26
 License: Elastic 2.0
 """
 

--- a/src/kg_rag/model_coordinator.py
+++ b/src/kg_rag/model_coordinator.py
@@ -67,7 +67,6 @@ CLI
 
 Author: Eric G. Suchanek, PhD
 License: Elastic 2.0
-Last Revision: 2026-04-26 02:25:38
 """
 
 from __future__ import annotations

--- a/src/kg_rag/orchestrator.py
+++ b/src/kg_rag/orchestrator.py
@@ -7,7 +7,6 @@ Loads adapters from the registry and executes federated queries across
 multiple KG instances (PyCodeKG, DocKG, MetaKG) simultaneously.
 
 Author: Eric G. Suchanek, PhD
-Last Revision: 2026-06-09 11:50:02
 License: Elastic 2.0
 """
 


### PR DESCRIPTION
Brings kg-rag onto the current fleet releases. No runtime behaviour changes.

## Floors

Declared in two places — the runtime deps and the dev group, which installs the
adapters so the suite exercises the real classes. Both moved together:

| package | was | now |
|---|---|---|
| `kgmodule-utils` | >=0.13.0 | >=0.13.2 |
| `pycode-kg` | >=0.22.0 | >=0.23.1 |
| `doc-kg` | >=0.21.1 | >=0.21.2 |
| `diary-kg` | >=0.96.0 | >=0.97.0 |
| `ftree-kg` | >=0.11.0 | unchanged — still the current release |

**0.13.1 is skipped fleet-wide.** It made `SnapshotManager.repo_root` a
read-only property, which breaks every subclass that assigns it. The comment on
the floor now records that, so it does not get "tidied" back to 0.13.0 by
someone reading only the TEIEmbedder rationale that was there before.

## The dev group becomes optional

`[tool.poetry.group.dev]` had no `optional = true`, so a bare `poetry install`
pulled pytest, ruff, ty, pre-commit, pdoc and pip-audit into a consumer's
environment. The header's install table already advertised
`poetry install --extras "all" --with dev` as the way to get dev tools — this
makes the behaviour match the documentation rather than the other way round.

CI now asks for the group explicitly at the typecheck and test jobs; the lint
job already used `--only dev` and is unchanged.

Unlike the other repos in this sweep, kg-rag's `all` extra needed no surgery —
it lists only feature packages, never dev tools. Confirmed against the wheel:

```
Provides-Extra: all, kg, pi, qt, viz, viz2d, viz3d      (no dev)
Requires-Dist:  no dev tool
                kgmodule-utils (>=0.13.2)
                diary-kg (>=0.97.0) ; extra == "kg" or extra == "all"
                doc-kg (>=0.21.2)   ; extra == "kg" or extra == "all"
                pycode-kg (>=0.23.1); extra == "kg" or extra == "all"
```

## ruff hook

Pinned at `v0.15.13` while the lock resolves `0.15.22`, so the hook and
`poetry run ruff` could disagree on formatting. The `<0.16` cap stays — 0.16
reformats Python inside Markdown code blocks, which rewrites hand-aligned
examples across 11 docs here, and that is an upgrade to adopt deliberately
rather than one a relock should smuggle in.

Per-file `Last Revision:` headers retired from 14 files (fleet standard,
2026-08-15).

## Verification

`env -u VIRTUAL_ENV -u POETRY_ACTIVE poetry run pre-commit run --all-files` —
12 hooks pass, **504 tests pass**. Wheel METADATA checked as above.

Committed with `KGRAG_SKIP_SNAPSHOT=1`. This repo's
`.git/hooks/pre-commit.legacy` (from `kgrag install-hooks`) rebuilds and
`git add`s KG snapshots in *sibling* repos — `pycode_kg`, `doc_kg`, `FTreeKG` —
and on the first attempt it raced pre-commit's own git plumbing, aborting the
commit and leaving orphan snapshots in two other working trees. Those were
reverted; the hook behaviour is worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
