### PR TITLE
chore: raise the ftree-kg floor to 0.13.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1411,27 +1411,26 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "ftree-kg"
-version = "0.11.0"
+version = "0.13.0"
 description = "KGModule for file tree knowledge graphs"
 optional = true
 python-versions = "<3.14,>=3.12"
 groups = ["main"]
 markers = "extra == \"kg\" or extra == \"all\""
 files = [
-    {file = "ftree_kg-0.11.0-py3-none-any.whl", hash = "sha256:78bd468df4fd7dac038dda4677ad9d00316f5f9bef25cee6ffbd3316b072fda3"},
-    {file = "ftree_kg-0.11.0.tar.gz", hash = "sha256:d79ea79f79e72c46040c238dc95dd5b12afa9acccf49ec49fe43904be6dde4fd"},
+    {file = "ftree_kg-0.13.0-py3-none-any.whl", hash = "sha256:d523376dec945ab10da07fee8bb3251a6c6dc65add17679b91109df4abe4a897"},
+    {file = "ftree_kg-0.13.0.tar.gz", hash = "sha256:141e80f18b99f2effce315f5845d17c27c9544ccaaebc613aff2dfe96910dfe6"},
 ]
 
 [package.dependencies]
 click = ">=8.1.0,<9"
-kgmodule-utils = {version = ">=0.9.0", extras = ["semantic", "sqlite-vec"]}
+kgmodule-utils = {version = ">=0.13.2", extras = ["semantic", "sqlite-vec"]}
+mcp = ">=1.0.0,<2"
 pillow = ">=10.0.0"
 rich = ">=13.0.0,<15.0.0"
 
 [package.extras]
-adapter = ["kg-rag (>=0.11.0)"]
-all = ["detect-secrets (>=1.5.0)", "pre-commit (>=4.5.1)", "pylint (>=4.0.5)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "ruff (>=0.4.0)", "ty (>=0.0.41)"]
-dev = ["detect-secrets (>=1.5.0)", "pre-commit (>=4.5.1)", "pylint (>=4.0.5)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "ruff (>=0.4.0)", "ty (>=0.0.41)"]
+adapter = ["kg-rag (>=0.12.0)"]
 
 [[package]]
 name = "h11"
@@ -6385,4 +6384,4 @@ viz3d = ["PyQt5", "markdown", "param", "pyvista", "pyvistaqt", "trame-vtk"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.14"
-content-hash = "c98497ff6246e7cbb537b15c7f6295b2c3d8a709eb6fd16fb77c253fcdbc2eb5"
+content-hash = "559b168bddc6b2ecd5bd7575e48c3c24179866e9d1029725d52272181dee101b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ llama-cpp-python = { version = ">=0.3.0", optional = true }
 kgmodule-utils = ">=0.13.2"
 pycode-kg = {version = ">=0.23.1", optional=true}
 doc-kg = {version = ">=0.21.2", optional=true}
-ftree-kg = {version = ">=0.11.0", optional=true}
+ftree-kg = {version = ">=0.13.0", optional=true}
 diary-kg  = {version = ">=0.97.0", optional = true}
 
 


### PR DESCRIPTION
The last stale floor in the fleet. `ftree-kg` has published 0.12.0 and 0.13.0 since, and kgrag was the only repo still declaring `>=0.11.0`.

| package | was | now |
|---|---|---|
| `ftree-kg` (kg extra) | >=0.11.0 | **>=0.13.0** |

## The adapters stay an extra, deliberately

Raised as a question during the sweep: should the adapters move to a Poetry group, matching how `doc-kg`/`pycode-kg` are declared in the other repos?

No — and the reason is that the **same packages play opposite roles**:

- In `Metabo_kg`, `agent_kg`, `memory_kg`, `tscode_kg`, `ftree_kg`, they are **CLIs the repo runs on itself** (hooks, MCP servers, index builds). Maintainer tooling → group.
- Here they are **libraries the package adapts at runtime for the user**. Federating across sibling KGs is what kg-rag is *for*. Feature → extra.

The decisive practical point: **groups cannot be installed by pip.** `pip install kg-rag[kg]` is documented at `pyproject.toml:39`; there is no pip equivalent for a Poetry group, so moving the adapters would make them unreachable for anyone installing from PyPI.

The split you would want already exists — the **dev group separately installs** `pycode-kg` and `doc-kg` so the suite exercises the real adapter classes, with a comment explaining that they are optional at runtime but not optional to test.

## Verification

Checked against the new floor rather than assumed: `ftree_kg` still exports `FileTreeKG` — the symbol `ftree_adapter.py` lazily imports — and `FTreeKGAdapter` still imports cleanly. **504 tests pass, 12 hooks pass.**

**Coverage gap worth knowing:** no test in this repo selects on ftree at all (`pytest -k "ftree or FTree"` deselects all 504). So this adapter's compatibility with a new ftree-kg rests on the import check above, not on coverage. The doc and pycode adapters are exercised; this one is not.

## A hook problem this surfaced

Committed with `KGRAG_SKIP_SNAPSHOT=1`. This repo's `.git/hooks/pre-commit.legacy` rebuilds and `git add`s KG snapshots in **sibling repos**. On the first attempt it did so into `pycode_kg` and `doc_kg` — both of which have open PRs of their own — then raced pre-commit's git plumbing and aborted the commit. In `doc_kg` it **deleted a snapshot that was already part of a pushed commit**.

Both were restored and verified identical to their pushed commits. The hook behaviour still wants its own fix — writing into repositories the user did not ask you to touch is not a safe default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)