### PR TITLE
fix(hooks): keep the pre-commit hook inside its own repository

### DIFF
--- a/src/kg_rag/cli/cmd_hooks.py
+++ b/src/kg_rag/cli/cmd_hooks.py
@@ -27,73 +27,75 @@ from kg_rag.cli.group import cli
 
 _PRE_COMMIT_HOOK = """\
 #!/usr/bin/env bash
-# KGRAG pre-commit hook — keeps registered KG indices in sync and captures
+# KGRAG pre-commit hook — rebuilds this repository's KG indices and captures
 # metrics snapshots BEFORE quality checks run.
 # Installed by: kgrag install-hooks
 # Skip with: KGRAG_SKIP_SNAPSHOT=1 git commit ...
+#
+# This hook touches THIS repository and nothing else. An earlier version walked
+# to the parent directory and rebuilt, snapshotted and `git add`ed inside
+# sibling checkouts (pycode_kg, doc_kg, FTreeKG). That is not a hook's business:
+# committing in one repo silently wrote into others, staged files there, and
+# tagged their snapshots with this repo's tree hash and branch name — so a
+# pycode_kg snapshot would claim to describe pycode_kg at a kgrag commit. It
+# also raced pre-commit's own git plumbing and aborted commits outright.
 set -euo pipefail
 
 [ "${KGRAG_SKIP_SNAPSHOT:-0}" = "1" ] && exit 0
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-WORKSPACE_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
-
 cd "$REPO_ROOT"
 
 # Capture the tree hash of the staged index NOW — before any tool modifies files.
 TREE_HASH=$(git write-tree)
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
 
-# ---------------------------------------------------------------------------
-# PyCodeKG — rebuild + snapshot if present in workspace
-# ---------------------------------------------------------------------------
-CODEKG_REPO="${WORKSPACE_ROOT}/pycode_kg"
-if [ -d "$CODEKG_REPO/.pycodekg" ]; then
-    (cd "$CODEKG_REPO" && "$CODEKG_REPO/.venv/bin/pycodekg" build --repo . || exit 1)
-    (cd "$CODEKG_REPO" && "$CODEKG_REPO/.venv/bin/pycodekg" snapshot save \\
-        --repo . \\
-        --tree-hash "$TREE_HASH" \\
-        --branch "$BRANCH") \\
-      || { echo "[kgrag] pycodekg snapshot skipped" >&2; }
-    (cd "$CODEKG_REPO" && git add .pycodekg/snapshots/ 2>/dev/null || true)
-fi
+# Resolve a CLI from this repo's venv first, then PATH. Absent is fine: a repo
+# that does not carry a given index simply skips it.
+_kg_bin() {
+    if [ -x "$REPO_ROOT/.venv/bin/$1" ]; then
+        echo "$REPO_ROOT/.venv/bin/$1"
+    elif command -v "$1" >/dev/null 2>&1; then
+        command -v "$1"
+    fi
+}
 
-# ---------------------------------------------------------------------------
-# DocKG — rebuild + snapshot if present in workspace
-# ---------------------------------------------------------------------------
-DOCKG_REPO="${WORKSPACE_ROOT}/doc_kg"
-if [ -d "$DOCKG_REPO/.dockg" ]; then
-    (cd "$DOCKG_REPO" && "$DOCKG_REPO/.venv/bin/dockg" build || exit 1)
-    (cd "$DOCKG_REPO" && "$DOCKG_REPO/.venv/bin/dockg" snapshot save \\
-        --repo . \\
-        --tree-hash "$TREE_HASH" \\
-        --branch "$BRANCH") \\
-      || { echo "[kgrag] dockg snapshot skipped" >&2; }
-    (cd "$DOCKG_REPO" && git add .dockg/snapshots/ 2>/dev/null || true)
-fi
+# build + snapshot + stage one index, all inside this repo.
+#   $1 CLI name   $2 index directory   $3 snapshot path to stage
+_kg_refresh() {
+    local cli="$1" dir="$2" staged="$3" bin
+    [ -d "$REPO_ROOT/$dir" ] || return 0
+    bin="$(_kg_bin "$cli")"
+    [ -n "$bin" ] || return 0
 
-# ---------------------------------------------------------------------------
-# FTreeKG — rebuild + snapshot if present in workspace
-# ---------------------------------------------------------------------------
-FTREEKG_REPO="${WORKSPACE_ROOT}/FTreeKG"
-if [ -d "$FTREEKG_REPO/.filetreekg" ]; then
-    (cd "$FTREEKG_REPO" && "$FTREEKG_REPO/.venv/bin/ftreekg" build --repo . --wipe || true)
-    (cd "$FTREEKG_REPO" && "$FTREEKG_REPO/.venv/bin/ftreekg" snapshot save \\
-        --repo . \\
-        --tree-hash "$TREE_HASH" \\
-        --branch "$BRANCH") \\
-      || { echo "[kgrag] ftreekg snapshot skipped" >&2; }
-    (cd "$FTREEKG_REPO" && git add .filetreekg/snapshots/ 2>/dev/null || true)
-fi
+    # No --wipe on any of these: a bare `build` rebuilds in full across the
+    # fleet, and passing the flag exits 2.
+    "$bin" build --repo "$REPO_ROOT" \
+      || { echo "[kgrag] $cli build failed — snapshot skipped" >&2; return 0; }
+    "$bin" snapshot save --repo "$REPO_ROOT" --tree-hash "$TREE_HASH" --branch "$BRANCH" \
+      || { echo "[kgrag] $cli snapshot skipped" >&2; return 0; }
+    git add "$staged" 2>/dev/null || true
+}
+
+_kg_refresh pycodekg .pycodekg .pycodekg/snapshots/
+_kg_refresh dockg    .dockg    .dockg/snapshots/
+_kg_refresh ftreekg  .filetreekg .filetreekg/snapshots/
 
 # ---------------------------------------------------------------------------
 # Run pre-commit framework checks AFTER all snapshots are captured and staged.
 # ---------------------------------------------------------------------------
-PRECOMMIT="$REPO_ROOT/.venv/bin/pre-commit"
-if [ -x "$PRECOMMIT" ]; then
-    "$PRECOMMIT" run || exit 1
-elif command -v pre-commit &>/dev/null; then
-    pre-commit run || exit 1
+# The config gate is load-bearing: `pre-commit run` exits non-zero with
+# "InvalidConfigError: .pre-commit-config.yaml is not a file" when there is no
+# config, so without it this hook blocks every commit in any repo that
+# installed it without also adopting pre-commit. Metabo_kg fixed the same
+# defect in its own hook.
+if [ -f "$REPO_ROOT/.pre-commit-config.yaml" ]; then
+    PRECOMMIT="$REPO_ROOT/.venv/bin/pre-commit"
+    if [ -x "$PRECOMMIT" ]; then
+        "$PRECOMMIT" run || exit 1
+    elif command -v pre-commit &>/dev/null; then
+        pre-commit run || exit 1
+    fi
 fi
 
 exit 0
@@ -116,12 +118,17 @@ exit 0
 def install_hooks(repo: str, force: bool) -> None:
     """Install the KGRAG pre-commit git hook.
 
-    After installation, before each commit the hook will:
-      1. Rebuild + snapshot PyCodeKG (if workspace/pycode_kg is built)
-      2. Rebuild + snapshot DocKG (if workspace/doc_kg is built)
-      3. Rebuild + snapshot FTreeKG (if workspace/FTreeKG is built)
-      4. Stage all snapshot directories atomically
-      5. Run pre-commit framework checks (ruff, mypy, etc.)
+    After installation, before each commit the hook will, **for this
+    repository only**:
+      1. Rebuild + snapshot PyCodeKG   (if ./.pycodekg exists)
+      2. Rebuild + snapshot DocKG      (if ./.dockg exists)
+      3. Rebuild + snapshot FTreeKG    (if ./.filetreekg exists)
+      4. Stage the snapshot directories it wrote
+      5. Run pre-commit framework checks (ruff, ty, etc.)
+
+    Each step is skipped when the index directory or the CLI is absent, so a
+    repo that carries only one of the three works unchanged. The hook never
+    touches a repository other than the one being committed to.
 
     Skip with: KGRAG_SKIP_SNAPSHOT=1 git commit ...
 
@@ -150,4 +157,4 @@ def install_hooks(repo: str, force: bool) -> None:
 
     click.echo(f"OK Installed pre-commit hook: {hook_path}")
     click.echo("  Snapshots will be captured automatically before each commit.")
-    click.echo("  Orchestrates: PyCodeKG, DocKG, FTreeKG (if built).")
+    click.echo("  Refreshes this repo's PyCodeKG / DocKG / FTreeKG indices, if present.")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,183 @@
+"""Tests for ``kgrag install-hooks`` — the generated pre-commit hook.
+
+The hook is an embedded shell string, so nothing type-checks it and nothing
+imports it. It had rotted into writing across repository boundaries: it walked
+to the parent directory and rebuilt, snapshotted and ``git add``ed inside
+sibling checkouts. Committing in one repo silently staged files in others.
+
+Nothing caught it because no test ever ran the hook. These do.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from kg_rag.cli.cmd_hooks import _PRE_COMMIT_HOOK
+from kg_rag.cli.group import cli
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="hook execution needs git and bash",
+)
+
+#: Git environment variables that bind a command to a *specific* repository.
+#: ``cwd=`` does not override them — git reads these first — so a test that only
+#: sets ``cwd`` still operates on whatever repo the caller was in. That matters
+#: here because the pytest pre-commit hook runs these tests *during* a commit.
+_GIT_REPO_ENV = (
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_WORK_TREE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_COMMON_DIR",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+)
+
+
+def _clean_env(**extra: str) -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k not in _GIT_REPO_ENV}
+    env.update(extra)
+    return env
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=False, env=_clean_env()
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real git repository with the hook installed."""
+    _git("init", "-q", ".", cwd=tmp_path)
+    _git("config", "user.email", "test@example.com", cwd=tmp_path)
+    _git("config", "user.name", "Test", cwd=tmp_path)
+    result = CliRunner().invoke(cli, ["install-hooks", "--repo", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    return tmp_path
+
+
+def _stage(repo: Path, name: str) -> None:
+    (repo / name).write_text("content\n")
+    _git("add", name, cwd=repo)
+
+
+class TestHookContents:
+    """What the script says, before worrying about what it does."""
+
+    def test_is_valid_bash(self, tmp_path: Path) -> None:
+        script = tmp_path / "hook.sh"
+        script.write_text(_PRE_COMMIT_HOOK)
+        assert subprocess.run(["bash", "-n", str(script)], check=False).returncode == 0
+
+    def test_does_not_walk_out_of_the_repository(self) -> None:
+        """The bug this file exists for: no reaching into sibling checkouts."""
+        assert "WORKSPACE_ROOT" not in _PRE_COMMIT_HOOK
+        assert "REPO_ROOT/.." not in _PRE_COMMIT_HOOK
+
+    def test_does_not_name_sibling_repositories(self) -> None:
+        for sibling in ("pycode_kg", "doc_kg", "FTreeKG", "ftree_kg"):
+            assert f"/{sibling}" not in _PRE_COMMIT_HOOK
+
+    def test_does_not_pass_wipe_to_a_full_build(self) -> None:
+        """`build` always wipes across the fleet; passing --wipe exits 2."""
+        code = [ln for ln in _PRE_COMMIT_HOOK.splitlines() if not ln.lstrip().startswith("#")]
+        assert not any("--wipe" in ln for ln in code)
+
+    def test_honours_the_skip_switch(self) -> None:
+        assert "KGRAG_SKIP_SNAPSHOT" in _PRE_COMMIT_HOOK
+
+
+class TestInstall:
+    def test_writes_an_executable_hook(self, repo: Path) -> None:
+        hook = repo / ".git" / "hooks" / "pre-commit"
+        assert hook.is_file()
+        assert hook.stat().st_mode & 0o111
+
+    def test_refuses_to_clobber_without_force(self, repo: Path) -> None:
+        result = CliRunner().invoke(cli, ["install-hooks", "--repo", str(repo)])
+        assert result.exit_code != 0
+        assert "--force" in result.output
+
+
+class TestHookExecution:
+    """Does a commit still go through?"""
+
+    def test_first_commit_in_a_fresh_repo_succeeds(self, repo: Path) -> None:
+        """Unborn HEAD — `rev-parse --abbrev-ref HEAD` is fatal there."""
+        _stage(repo, "a.txt")
+        result = _git("commit", "-m", "init", cwd=repo)
+        assert result.returncode == 0, result.stderr
+
+    def test_subsequent_commits_succeed(self, repo: Path) -> None:
+        _stage(repo, "a.txt")
+        _git("commit", "-m", "init", cwd=repo)
+        _stage(repo, "b.txt")
+        result = _git("commit", "-m", "second", cwd=repo)
+        assert result.returncode == 0, result.stderr
+
+    def test_exits_zero_when_no_kg_indices_are_present(self, repo: Path) -> None:
+        """A repo with no .pycodekg/.dockg/.filetreekg must commit unimpeded."""
+        _stage(repo, "a.txt")
+        _git("commit", "-m", "init", cwd=repo)
+        result = subprocess.run(
+            ["bash", str(repo / ".git" / "hooks" / "pre-commit")],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            env=_clean_env(),
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_skip_switch_short_circuits(self, repo: Path) -> None:
+        _stage(repo, "a.txt")
+        _git("commit", "-m", "init", cwd=repo)
+        result = subprocess.run(
+            ["bash", str(repo / ".git" / "hooks" / "pre-commit")],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            env={"PATH": "/usr/bin:/bin", "KGRAG_SKIP_SNAPSHOT": "1", "HOME": str(repo)},
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+class TestRepositoryIsolation:
+    """The regression itself: a commit here must not write there."""
+
+    def test_a_sibling_repository_is_left_untouched(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+
+        sibling = workspace / "pycode_kg"
+        (sibling / ".pycodekg" / "snapshots").mkdir(parents=True)
+        _git("init", "-q", ".", cwd=sibling)
+        _git("config", "user.email", "t@e.com", cwd=sibling)
+        _git("config", "user.name", "T", cwd=sibling)
+        (sibling / ".pycodekg" / "snapshots" / "keep.json").write_text("{}\n")
+        _git("add", "-A", cwd=sibling)
+        _git("commit", "-q", "-m", "sibling baseline", cwd=sibling)
+        before = _git("rev-parse", "HEAD", cwd=sibling).stdout.strip()
+
+        main = workspace / "kgrag"
+        main.mkdir()
+        _git("init", "-q", ".", cwd=main)
+        _git("config", "user.email", "t@e.com", cwd=main)
+        _git("config", "user.name", "T", cwd=main)
+        assert CliRunner().invoke(cli, ["install-hooks", "--repo", str(main)]).exit_code == 0
+
+        _stage(main, "a.txt")
+        assert _git("commit", "-m", "init", cwd=main).returncode == 0
+
+        assert _git("rev-parse", "HEAD", cwd=sibling).stdout.strip() == before
+        assert _git("status", "--porcelain", cwd=sibling).stdout == "", (
+            "committing in one repository must not stage or modify files in another"
+        )


### PR DESCRIPTION
The generated hook walked to the parent directory and wrote into sibling checkouts:

```bash
WORKSPACE_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
CODEKG_REPO="${WORKSPACE_ROOT}/pycode_kg"
(cd "$CODEKG_REPO" && ... && git add .pycodekg/snapshots/)
```

So committing in kgrag rebuilt, snapshotted and **staged files** in `pycode_kg`, `doc_kg` and `FTreeKG`.

## What it actually did, observed

During the fleet sweep a single commit here:

- staged files in two repositories that had **open PRs of their own**
- **deleted a snapshot in `doc_kg` that was already part of a pushed commit**
- raced pre-commit's git plumbing and **aborted the commit outright**, twice, with `fatal: unable to read <object>`

The snapshots were wrong as well as unwelcome: it tagged them with *this* repo's tree hash and branch, so a pycode_kg snapshot claimed to describe pycode_kg at a kgrag commit.

## The fix

The hook refreshes **this repository's own** indices — `.pycodekg`, `.dockg`, `.filetreekg` — and nothing else. kgrag carries all three, so the intent is unchanged; only the target is. Each step is skipped when the index directory or the CLI is absent.

Three further defects went with it:

| defect | effect |
|---|---|
| `ftreekg build --repo . --wipe` | no build command in the fleet accepts `--wipe`; passing it exits 2 |
| `${WORKSPACE_ROOT}/FTreeKG` | that path does not exist — the repo is `ftree_kg`. The branch had **never run** |
| `pre-commit run` called unconditionally | exits non-zero with `InvalidConfigError: .pre-commit-config.yaml is not a file`, so the hook **blocked every commit** in any repo that installed it without adopting pre-commit |

Metabo_kg fixed that last one in its own hook already; this matches it.

## Tests, which did not exist

That absence is why none of this was caught. `tests/test_hooks.py` now runs the hook — a real `git init`, a real commit, a real exit code — including:

- **an isolation test** that builds a sibling repo and asserts a commit in one leaves the other's HEAD and working tree untouched
- content assertions that the script never names a sibling or walks to `..`
- the unborn-HEAD case, the no-indices case, and the skip switch

The helpers strip the six `GIT_*` variables that bind a command to a specific repository — without that the tests operate on the outer repo when run from a hook, which is the failure mode found in Metabo_kg this week.

## Verification

**516 tests pass, 12 hooks pass.** And empirically: the commit on this branch left `pycode_kg` and `doc_kg` at 0 modified files, where the old hook dirtied both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)