### PR TITLE
chore(snapshots): relativize historical db_path values

### DIFF
--- a/.dockg/snapshots/10ac32328ca0f3b6baf01e4e8d1588c64f75cd87.json
+++ b/.dockg/snapshots/10ac32328ca0f3b6baf01e4e8d1588c64f75cd87.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-04-17T21:22:23.631133+00:00",
   "version": "0.7.0",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 10343,
     "total_edges": 84852,
     "node_counts": {

--- a/.dockg/snapshots/14ee905aebe477097d662e1f66b01357b463a20b.json
+++ b/.dockg/snapshots/14ee905aebe477097d662e1f66b01357b463a20b.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-04-16T04:10:31.889674+00:00",
   "version": "0.7.0",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 10155,
     "total_edges": 83219,
     "node_counts": {

--- a/.dockg/snapshots/1e78e47fd9ae53bf9de7b7022e6e1988f7aa5068.json
+++ b/.dockg/snapshots/1e78e47fd9ae53bf9de7b7022e6e1988f7aa5068.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-03-31T22:54:12.794098+00:00",
   "version": "0.5.1",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 9450,
     "total_edges": 76677,
     "node_counts": {

--- a/.dockg/snapshots/2ba15d03842953ae8bdd53f829c073aef9fb7d6a.json
+++ b/.dockg/snapshots/2ba15d03842953ae8bdd53f829c073aef9fb7d6a.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-03-31T22:59:16.176608+00:00",
   "version": "0.5.1",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 9448,
     "total_edges": 76649,
     "node_counts": {

--- a/.dockg/snapshots/2d0a87b9268302984791cefdc128d0798935faee.json
+++ b/.dockg/snapshots/2d0a87b9268302984791cefdc128d0798935faee.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-04-16T12:11:26.867852+00:00",
   "version": "0.7.0",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 10262,
     "total_edges": 84481,
     "node_counts": {

--- a/.dockg/snapshots/57188084793736d70ae1e86cdcd1f2abbb8e57ab.json
+++ b/.dockg/snapshots/57188084793736d70ae1e86cdcd1f2abbb8e57ab.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-04-17T16:24:47.957862+00:00",
   "version": "0.7.0",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 6200,
     "total_edges": 48257,
     "node_counts": {

--- a/.dockg/snapshots/79d2667f8a4b3ee3ec74598193ee122a8e6686d0.json
+++ b/.dockg/snapshots/79d2667f8a4b3ee3ec74598193ee122a8e6686d0.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-04-17T16:37:07.682235+00:00",
   "version": "0.7.0",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 10287,
     "total_edges": 84631,
     "node_counts": {

--- a/.dockg/snapshots/8e726dea777e3c755b32698a41585a28561a3054.json
+++ b/.dockg/snapshots/8e726dea777e3c755b32698a41585a28561a3054.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-03-31T23:00:54.237679+00:00",
   "version": "0.5.1",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 9448,
     "total_edges": 76649,
     "node_counts": {

--- a/.dockg/snapshots/9c24357dc519305118ec20fea2e7c98f37365001.json
+++ b/.dockg/snapshots/9c24357dc519305118ec20fea2e7c98f37365001.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-03-31T23:02:14.383236+00:00",
   "version": "0.5.1",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 9448,
     "total_edges": 76649,
     "node_counts": {

--- a/.dockg/snapshots/9cfb7637bea115948f3eeb62abe5308184cd40a8.json
+++ b/.dockg/snapshots/9cfb7637bea115948f3eeb62abe5308184cd40a8.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-03-31T22:50:06.292221+00:00",
   "version": "0.5.1",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 9444,
     "total_edges": 76656,
     "node_counts": {

--- a/.dockg/snapshots/a072575cd129773289eb7e37829bf5e0ddb24b5b.json
+++ b/.dockg/snapshots/a072575cd129773289eb7e37829bf5e0ddb24b5b.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-04-18T02:02:10.132272+00:00",
   "version": "0.7.0",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 10346,
     "total_edges": 84910,
     "node_counts": {

--- a/.dockg/snapshots/a28ef956fda1d313c27140fd096afc602bd69187.json
+++ b/.dockg/snapshots/a28ef956fda1d313c27140fd096afc602bd69187.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-04-06T22:36:38.447500+00:00",
   "version": "0.7.0",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 9529,
     "total_edges": 77578,
     "node_counts": {

--- a/.dockg/snapshots/b3d1d97cb7d8966939ac7bf23eccc086db0ba55a.json
+++ b/.dockg/snapshots/b3d1d97cb7d8966939ac7bf23eccc086db0ba55a.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-04-17T16:33:40.901246+00:00",
   "version": "0.7.0",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 10277,
     "total_edges": 84590,
     "node_counts": {

--- a/.dockg/snapshots/bf908077131982154e884d29ecd9a3e15377125e.json
+++ b/.dockg/snapshots/bf908077131982154e884d29ecd9a3e15377125e.json
@@ -4,7 +4,7 @@
   "timestamp": "2026-04-17T01:49:39.989705+00:00",
   "version": "0.7.0",
   "metrics": {
-    "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+    "db_path": ".dockg/graph.sqlite",
     "total_nodes": 10280,
     "total_edges": 84636,
     "node_counts": {

--- a/.dockg/snapshots/manifest.json
+++ b/.dockg/snapshots/manifest.json
@@ -214,7 +214,7 @@
       "version": "0.5.1",
       "file": "9cfb7637bea115948f3eeb62abe5308184cd40a8.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 9444,
         "total_edges": 76656,
         "node_counts": {
@@ -257,7 +257,7 @@
       "version": "0.5.1",
       "file": "1e78e47fd9ae53bf9de7b7022e6e1988f7aa5068.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 9450,
         "total_edges": 76677,
         "node_counts": {
@@ -300,7 +300,7 @@
       "version": "0.5.1",
       "file": "2ba15d03842953ae8bdd53f829c073aef9fb7d6a.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 9448,
         "total_edges": 76649,
         "node_counts": {
@@ -343,7 +343,7 @@
       "version": "0.5.1",
       "file": "8e726dea777e3c755b32698a41585a28561a3054.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 9448,
         "total_edges": 76649,
         "node_counts": {
@@ -386,7 +386,7 @@
       "version": "0.5.1",
       "file": "9c24357dc519305118ec20fea2e7c98f37365001.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 9448,
         "total_edges": 76649,
         "node_counts": {
@@ -429,7 +429,7 @@
       "version": "0.7.0",
       "file": "a28ef956fda1d313c27140fd096afc602bd69187.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 9529,
         "total_edges": 77578,
         "node_counts": {
@@ -472,7 +472,7 @@
       "version": "0.7.0",
       "file": "14ee905aebe477097d662e1f66b01357b463a20b.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 10155,
         "total_edges": 83219,
         "node_counts": {
@@ -515,7 +515,7 @@
       "version": "0.7.0",
       "file": "2d0a87b9268302984791cefdc128d0798935faee.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 10262,
         "total_edges": 84481,
         "node_counts": {
@@ -558,7 +558,7 @@
       "version": "0.7.0",
       "file": "bf908077131982154e884d29ecd9a3e15377125e.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 10280,
         "total_edges": 84636,
         "node_counts": {
@@ -601,7 +601,7 @@
       "version": "0.7.0",
       "file": "b3d1d97cb7d8966939ac7bf23eccc086db0ba55a.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 10277,
         "total_edges": 84590,
         "node_counts": {
@@ -644,7 +644,7 @@
       "version": "0.7.0",
       "file": "79d2667f8a4b3ee3ec74598193ee122a8e6686d0.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 10287,
         "total_edges": 84631,
         "node_counts": {
@@ -687,7 +687,7 @@
       "version": "0.7.0",
       "file": "10ac32328ca0f3b6baf01e4e8d1588c64f75cd87.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 10343,
         "total_edges": 84852,
         "node_counts": {
@@ -730,7 +730,7 @@
       "version": "0.7.0",
       "file": "a072575cd129773289eb7e37829bf5e0ddb24b5b.json",
       "metrics": {
-        "db_path": "/Users/egs/repos/kgrag/.dockg/graph.sqlite",
+        "db_path": ".dockg/graph.sqlite",
         "total_nodes": 10346,
         "total_edges": 84910,
         "node_counts": {


### PR DESCRIPTION
Removes the author home directory and username from 27 tracked snapshot entries across 15 file(s).

kgmodule-utils >=0.13.2 already relativizes `db_path` on write (`SnapshotManager._relativize_paths`); this is the historical residue written before that, scrubbed by the same rule — an in-repo path becomes repo-relative, anything outside is left alone. `tscode_kg` has been clean this way all along and was the reference implementation.

**Only the `db_path` value changes.** Timestamps, metrics, hotspots and deltas are byte-identical, so snapshot history, `viz-timeline` and `snapshot diff` keep their full record — nothing is untracked or discarded.

Verified: every snapshot JSON still parses, and the snapshot history still reads back in full.

Part of the fleet path-leak cleanup (pass 1), tracked in kgrag_priv/FLEET_SWEEP_PLAN.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)