### PR TITLE
chore(deps): convert to PEP 621, retune the kg extra, fix MemoryKGAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`memory-kg` is now a declared dependency** (the `kg` and `all` extras).
+  It was in no extra at all, so a registered `kind=memory` KG could never be
+  queried through KGRAG on a stock install -- `kgrag query --kind memory`
+  reported "No available KGs to query" no matter how the KG was built. It is
+  on PyPI and is floored at `>=0.7.0`.
+
+### Fixed
+
+- **`MemoryKGAdapter` no longer raises on load.** It passed `lancedb_dir=` to
+  `MemoryKG.__init__`, a parameter memory-kg dropped in 0.7.0 when it moved to
+  sqlite-vec, so every construction died with `TypeError: unexpected keyword
+  argument 'lancedb_dir'`. It now passes `vectors_path=` instead, and leaves it
+  `None` for the default layout so memory-kg derives the sidecar next to the
+  graph -- the same idiom `DocKGAdapter` already used.
+
 ### Changed
 
+- **`pyproject.toml` converted to PEP 621.** Metadata, extras, URLs and console
+  scripts moved from `[tool.poetry]` to the standard `[project]`,
+  `[project.optional-dependencies]`, `[project.urls]` and `[project.scripts]`
+  tables, matching `gutenberg_kg`. `[tool.poetry]` now carries only `packages`,
+  plus the `torch` source enrichment PEP 621 cannot express and the optional
+  dependency groups. Resolution is unchanged: the regenerated lock installs the
+  identical package set at identical versions.
+- **`diary-kg` and `ftree-kg` moved out of the `kg` extra** into their own
+  `diary` and `filetree` extras. They back KG kinds most registries never hold,
+  and `diary-kg` pulls spacy (~21M) for a backend that then sits unused. `kg`
+  now carries the three that a typical registry leans on -- `pycode-kg`
+  (`code`), `doc-kg` (`doc`, and every `gutenberg` KG, which queries through
+  `DocKG`) and `memory-kg` (`memory`). `all` is unchanged and still installs
+  every one of them. **Breaking** for anyone who relied on `kg-rag[kg]` to
+  supply diary or filetree support; install `kg-rag[kg,diary,filetree]`.
+- **`[tool.memorykg]` rewritten to the keys memory-kg actually reads.** The
+  block declared `source`, `extra`, `output` and `corpus_name` -- none of which
+  anything reads -- and its comment documented `memorykg build --source ...
+  --extra ...`, flags the CLI no longer has. `exclude` is the only key
+  `memory_kg.config.load_exclude_dirs` looks for, so the ten exclusions had to
+  be repeated by hand as `--exclude-dir` on every rebuild. Rebuilding the
+  `claude_t_self` corpus is now just `memorykg build --repo .`.
+- **Dropped the orphaned `spacy` dependency.** It was marked `optional = true`
+  but listed in no extra, so no install could ever select it, and nothing in
+  `src/` or `tests/` imports it. It still arrives transitively via `diary-kg`.
 - **`torch` routes to the CPU-only wheel index on Linux** (`pyproject.toml`).
   The default PyPI Linux wheel bundles the full CUDA runtime (~2.7G of
   `nvidia-*` packages, ~700M of `triton`) regardless of whether a GPU is

--- a/README.md
+++ b/README.md
@@ -91,14 +91,20 @@ pip install kg-rag
 # With Streamlit dashboard
 pip install 'kg-rag[viz]'
 
-# With PyCodeKG / DocKG / FTreeKG adapters
+# With the common adapter backends (PyCodeKG, DocKG, MemoryKG).
+# DocKG also backs every GutenbergKG corpus, which queries through it.
 pip install 'kg-rag[kg]'
 
-# With multi-format document ingestion (PDF, Word, PowerPoint, Excel, EPUB, …)
+# DiaryKG and FileTreeKG back kinds most registries never hold, so they
+# have their own extras rather than riding along with [kg].
+pip install 'kg-rag[diary]'
+pip install 'kg-rag[filetree]'
+
+# With multi-format document ingestion (PDF, Word, PowerPoint, Excel, EPUB, ...)
 pip install 'kg-rag[ingest]'
 
-# With git-sourced adapters (AgentKG, DiaryKG, MetaboKG, MemoryKG) — Poetry only
-poetry install --with kgdeps
+# Everything except [pi], which needs a compiler toolchain
+pip install 'kg-rag[all]'
 ```
 
 ```bash

--- a/poetry.lock
+++ b/poetry.lock
@@ -118,6 +118,7 @@ description = "The Blis BLAS-like linear algebra library, as a self-contained C-
 optional = true
 python-versions = "<3.15,>=3.9"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "blis-1.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:650f1d2b28e3c875927c63deebda463a6f9d237dff30e445bfe2127718c1a344"},
     {file = "blis-1.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9b0d42420ddd543eec51ccb99d38364a0c0833b6895eced37127822de6ecacff"},
@@ -207,6 +208,7 @@ description = "Super lightweight function registries for your library"
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "catalogue-2.0.10-py3-none-any.whl", hash = "sha256:58c2de0020aa90f4a2da7dfad161bf7b3b054c86a5f09fcedc0b2b740c109a9f"},
     {file = "catalogue-2.0.10.tar.gz", hash = "sha256:4f56daa940913d3f09d589c191c74e5a6d51762b3a9e37dd53b7437afd6cda15"},
@@ -531,6 +533,7 @@ files = [
     {file = "charset_normalizer-3.5.0-py3-none-any.whl", hash = "sha256:993dfcbe75a85a3784abb5084f2c41b915767c90546fcc92803cffa28611baea"},
     {file = "charset_normalizer-3.5.0.tar.gz", hash = "sha256:49bd5feb59b0bf3cbf6ebcf4352e371c95b9da9bacd4449f8b64d0ad2c10a26e"},
 ]
+markers = {main = "extra == \"diary\" or extra == \"all\" or extra == \"viz\" or extra == \"viz3d\""}
 
 [[package]]
 name = "click"
@@ -554,6 +557,7 @@ description = "pathlib-style classes for cloud storage services."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "cloudpathlib-0.24.0-py3-none-any.whl", hash = "sha256:b1c51e2d2ec7dc4fed6538991f4aea849d6cf11a7e6b9069f86e461aa1f9b5b4"},
     {file = "cloudpathlib-0.24.0.tar.gz", hash = "sha256:c521a984e77b47e656fe78e20a7e3e260e0ab45fc69e33ac01094227c979e34a"},
@@ -572,11 +576,11 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main", "dev"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\" and (extra == \"diary\" or extra == \"all\" or extra == \"viz\")", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "confection"
@@ -585,6 +589,7 @@ description = "The sweetest config system for Python"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "confection-1.3.3-py3-none-any.whl", hash = "sha256:b9fef9ee84b237ef4611ec3eb5797b70e13063e6310ad9f15536373f5e313c82"},
     {file = "confection-1.3.3.tar.gz", hash = "sha256:f0f6810d567ff73993fe74d218ca5e1ffb6a44fb03f391257fc5d033546cbfaa"},
@@ -944,6 +949,7 @@ nvidia-cuda-cupti = {version = "==13.0.85.*", optional = true, markers = "(sys_p
 nvidia-cuda-nvrtc = {version = "==13.0.88.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and (extra == \"cublas\" or extra == \"nvrtc\")"}
 nvidia-cuda-runtime = {version = "==13.0.96.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cudart\""}
 nvidia-cufft = {version = "==12.0.0.61.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cufft\""}
+nvidia-cufile = {version = "==1.15.1.6.*", optional = true, markers = "sys_platform == \"linux\" and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cufile\""}
 nvidia-curand = {version = "==10.4.0.35.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"curand\""}
 nvidia-cusolver = {version = "==12.0.4.66.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cusolver\""}
 nvidia-cusparse = {version = "==12.6.3.3.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and (extra == \"cusolver\" or extra == \"cusparse\")"}
@@ -1054,6 +1060,7 @@ description = "Manage calls to calloc/free through Cython"
 optional = true
 python-versions = "<3.15,>=3.9"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "cymem-2.0.13-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8efc4f308169237aade0e82877a65a563833dec32eb7ab2326120253e0e9e918"},
     {file = "cymem-2.0.13-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e03bb575a96c59bc210d7d59862747f0012696b0dac3427ce8af33c7afb3d4a2"},
@@ -1161,7 +1168,7 @@ description = "A knowledge graph builder and semantic search engine for diaries 
 optional = true
 python-versions = "<3.14,>=3.12"
 groups = ["main"]
-markers = "extra == \"kg\" or extra == \"all\""
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "diary_kg-0.97.0-py3-none-any.whl", hash = "sha256:398bad39475e2423f8d5c48b76c32be21516fb7732b08ef605981c8e3132e700"},
     {file = "diary_kg-0.97.0.tar.gz", hash = "sha256:f7712acaee94f8aaa449844dfe079e781cda2108b0a31d6281b52c9be6d2e00c"},
@@ -1218,7 +1225,7 @@ files = [
     {file = "doc_kg-0.21.2-py3-none-any.whl", hash = "sha256:56a9daca368d96c782b96bc5e238c3b1ea03ec84a35784b0e2c469badbe723f2"},
     {file = "doc_kg-0.21.2.tar.gz", hash = "sha256:d02fa9b25b50512bf0fbbf574861cd28c6a8a82f0602528f8e8e212940dca363"},
 ]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
+markers = {main = "extra == \"kg\" or extra == \"all\" or extra == \"diary\""}
 
 [package.dependencies]
 click = ">=8.1.0,<9"
@@ -1311,7 +1318,7 @@ groups = ["main", "dev"]
 files = [
     {file = "flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4"},
 ]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
+markers = {main = "extra == \"kg\" or extra == \"all\" or extra == \"diary\""}
 
 [[package]]
 name = "fonttools"
@@ -1434,7 +1441,7 @@ description = "KGModule for file tree knowledge graphs"
 optional = true
 python-versions = "<3.14,>=3.12"
 groups = ["main"]
-markers = "extra == \"kg\" or extra == \"all\""
+markers = "extra == \"filetree\" or extra == \"all\""
 files = [
     {file = "ftree_kg-0.13.0-py3-none-any.whl", hash = "sha256:d523376dec945ab10da07fee8bb3251a6c6dc65add17679b91109df4abe4a897"},
     {file = "ftree_kg-0.13.0.tar.gz", hash = "sha256:141e80f18b99f2effce315f5845d17c27c9544ccaaebc613aff2dfe96910dfe6"},
@@ -2353,6 +2360,38 @@ files = [
 ]
 
 [[package]]
+name = "memory-kg"
+version = "0.7.0"
+description = "A tool to build a semantically searchable knowledge graph from memories"
+optional = true
+python-versions = "<3.14,>=3.12"
+groups = ["main"]
+markers = "extra == \"kg\" or extra == \"all\""
+files = [
+    {file = "memory_kg-0.7.0-py3-none-any.whl", hash = "sha256:c34007c1635c2631f19ba22c014b8b8d9778e76ecc9f9c350571d90d4afaa1db"},
+    {file = "memory_kg-0.7.0.tar.gz", hash = "sha256:fcf926e9513fb72779d9e366b0ca10162cfbe618768923c458a7dc1a9ec2f3e9"},
+]
+
+[package.dependencies]
+click = ">=8.1.0,<9"
+kgmodule-utils = {version = ">=0.10.0", extras = ["sqlite-vec"]}
+markdown-it-py = ">=3.0.0"
+mcp = ">=1.0.0,<2"
+numpy = ">=1.24.0"
+pandas = ">=2.0.0"
+pyyaml = ">=6.0.0"
+rich = ">=14.3.3,<15"
+safetensors = ">=0.5.0"
+sentence-transformers = ">=5.4.1"
+torch = ">=2.5.1"
+transformers = ">=5.5.0,<6"
+
+[package.extras]
+all = ["detect-secrets (>=1.5.0)", "pdoc (>=14.0.0)", "plotly (>=5.14.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "pyvis (>=0.3.2)", "ruff (>=0.4.0)", "streamlit (>=1.35.0)", "ty (>=0.0.41)"]
+dev = ["detect-secrets (>=1.5.0)", "pdoc (>=14.0.0)", "pre-commit (>=4.5.1)", "pytest (>=8.0.0)", "pytest-cov (>=5.0.0)", "ruff (>=0.4.0)", "ty (>=0.0.41)"]
+viz = ["plotly (>=5.14.0)", "pyvis (>=0.3.2)", "streamlit (>=1.35.0)"]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
@@ -2453,6 +2492,7 @@ description = "Cython bindings for MurmurHash"
 optional = true
 python-versions = "<3.15,>=3.6"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "murmurhash-1.0.15-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f4989c16053a9a83b02c520dd00a31f0877d5fd2ab8a9b6b75ed9eba0e25c489"},
     {file = "murmurhash-1.0.15-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:899068ba3d7c371e7edd093852c634cce802fefd9aaddfcc0d2fda1d7433c7f9"},
@@ -2782,6 +2822,19 @@ files = [
 nvidia-nvjitlink = "*"
 
 [[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+description = "cuFile GPUDirect libraries"
+optional = false
+python-versions = ">=3"
+groups = ["main", "dev"]
+markers = "<empty>"
+files = [
+    {file = "nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44"},
+    {file = "nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1"},
+]
+
+[[package]]
 name = "nvidia-curand"
 version = "10.4.0.35"
 description = "CURAND native runtime libraries"
@@ -2949,7 +3002,7 @@ files = [
     {file = "onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e562d6e36a749f6764481c0ddb0f2af3d0b5a3c164291361d08803c557f369af"},
     {file = "onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f6e92367ddce1e4d33cf295024f40192be6c6171a09208f515ba169ced06c8e"},
 ]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
+markers = {main = "extra == \"kg\" or extra == \"all\" or extra == \"diary\""}
 
 [package.dependencies]
 flatbuffers = "*"
@@ -3138,7 +3191,7 @@ description = "Pexpect allows easy control of interactive console applications."
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"viz\" or extra == \"all\") and sys_platform != \"win32\" and sys_platform != \"emscripten\""
+markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\" and (extra == \"viz\" or extra == \"all\")"
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
     {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
@@ -3243,7 +3296,7 @@ files = [
     {file = "pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a"},
     {file = "pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"viz3d\" or extra == \"kg\""}
+markers = {main = "extra == \"filetree\" or extra == \"all\" or extra == \"viz\" or extra == \"viz3d\""}
 
 [package.extras]
 docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
@@ -3438,6 +3491,7 @@ description = "Cython hash table that trusts the keys are pre-hashed"
 optional = true
 python-versions = "<3.15,>=3.9"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "preshed-3.0.13-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:42c58b07e8b431e33d0ad9922e896632453821cad8b09171b619b8c61101916f"},
     {file = "preshed-3.0.13-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a06e27f4e5b9d7943840087828c6a0dae4a3475576d12c2e95b71abbb325a80b"},
@@ -3535,7 +3589,7 @@ files = [
     {file = "protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9"},
     {file = "protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a"},
 ]
-markers = {main = "extra == \"viz\" or extra == \"all\" or extra == \"kg\""}
+markers = {main = "extra == \"kg\" or extra == \"all\" or extra == \"diary\" or extra == \"viz\""}
 
 [[package]]
 name = "psutil"
@@ -3567,7 +3621,7 @@ files = [
     {file = "psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee"},
     {file = "psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"},
 ]
-markers = {main = "(extra == \"viz\" or extra == \"all\" or extra == \"kg\") and sys_platform != \"emscripten\" and sys_platform != \"cygwin\" or extra == \"kg\" or extra == \"all\""}
+markers = {main = "sys_platform == \"linux\" and (extra == \"viz\" or extra == \"all\" or extra == \"kg\" or extra == \"diary\") or (extra == \"kg\" or extra == \"all\" or extra == \"diary\" or extra == \"viz\") and sys_platform != \"emscripten\" and sys_platform != \"cygwin\" or extra == \"kg\" or extra == \"all\" or extra == \"diary\""}
 
 [package.extras]
 dev = ["abi3audit", "black", "check-manifest", "colorama ; os_name == \"nt\"", "coverage", "packaging", "psleak", "pylint", "pyperf", "pypinfo", "pyreadline3 ; os_name == \"nt\"", "pytest", "pytest-cov", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "validate-pyproject[all]", "virtualenv", "vulture", "wheel", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
@@ -3580,7 +3634,7 @@ description = "Run a subprocess in a pseudo terminal"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"viz\" or extra == \"all\") and sys_platform != \"win32\" and sys_platform != \"emscripten\""
+markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\" and (extra == \"viz\" or extra == \"all\")"
 files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
@@ -3975,7 +4029,7 @@ files = [
     {file = "pymupdf-1.28.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:fd481ed48bef56305c41fb7e05a055c03345c899c7b101dad086258b438f8168"},
     {file = "pymupdf-1.28.2.tar.gz", hash = "sha256:5e0be7908a715aa20333caddd73f1d6f01e4cd0c26e869fa2dd0b7f344da2249"},
 ]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
+markers = {main = "extra == \"kg\" or extra == \"all\" or extra == \"diary\""}
 
 [[package]]
 name = "pymupdf-layout"
@@ -3991,7 +4045,7 @@ files = [
     {file = "pymupdf_layout-1.28.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4b44a1d8ebf897b0e862ee2d73e7df73099f1c047fc024d2dd24ef0632d2cb5f"},
     {file = "pymupdf_layout-1.28.2-cp310-abi3-win_amd64.whl", hash = "sha256:a765d3ba0b1622e8d5794772ad4303d824386f04b382a5d31c999a828ed4a089"},
 ]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
+markers = {main = "extra == \"kg\" or extra == \"all\" or extra == \"diary\""}
 
 [package.dependencies]
 networkx = "*"
@@ -4011,7 +4065,7 @@ files = [
     {file = "pymupdf4llm-1.28.2-py3-none-any.whl", hash = "sha256:55c06c07d128f94c4d9271bd427d16ee219779e7d796a7b9da4e110be3004d96"},
     {file = "pymupdf4llm-1.28.2.tar.gz", hash = "sha256:02681698ef67bda9a2acd5d9e1115d4e88be0eb9c5d68926e5e3cd98cd351874"},
 ]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
+markers = {main = "extra == \"kg\" or extra == \"all\" or extra == \"diary\""}
 
 [package.dependencies]
 psutil = "*"
@@ -4556,6 +4610,7 @@ files = [
     {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
     {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
 ]
+markers = {main = "extra == \"diary\" or extra == \"all\" or extra == \"viz\" or extra == \"viz3d\""}
 
 [package.dependencies]
 certifi = ">=2023.5.7"
@@ -5021,6 +5076,7 @@ description = "Utils for streaming large files (S3, HDFS, GCS, SFTP, Azure Blob 
 optional = true
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "smart_open-8.0.1-py3-none-any.whl", hash = "sha256:3e97f90e92a952cb57863dfe132082c400a52eeeb27c067692fb51dbcc5b0089"},
     {file = "smart_open-8.0.1.tar.gz", hash = "sha256:18b1c4496003c6902be17c15f032b5c319f307c89c6ae9e6b028b508bed8b2cf"},
@@ -5060,6 +5116,7 @@ description = "Industrial-strength Natural Language Processing (NLP) in Python"
 optional = true
 python-versions = "<3.15,>=3.9"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "spacy-3.8.15-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1c8a27500b409b472a743c2b0b2af2dff42f4287ace36f2b776e4592d65ab493"},
     {file = "spacy-3.8.15-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0262f86956e751ace6e47e530cf9841d66f2354d8cd91cfeeb39eee4c5f2962f"},
@@ -5149,6 +5206,7 @@ description = "Legacy registered functions for spaCy backwards compatibility"
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "spacy-legacy-3.0.12.tar.gz", hash = "sha256:b37d6e0c9b6e1d7ca1cf5bc7152ab64a4c4671f59c85adaf7a3fcb870357a774"},
     {file = "spacy_legacy-3.0.12-py2.py3-none-any.whl", hash = "sha256:476e3bd0d05f8c339ed60f40986c07387c0a71479245d6d0f4298dbd52cda55f"},
@@ -5161,6 +5219,7 @@ description = "Logging utilities for SpaCy"
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "spacy-loggers-1.0.5.tar.gz", hash = "sha256:d60b0bdbf915a60e516cc2e653baeff946f0cfc461b452d11a4d5458c6fe5f24"},
     {file = "spacy_loggers-1.0.5-py3-none-any.whl", hash = "sha256:196284c9c446cc0cdb944005384270d775fdeaf4f494d8e269466cfa497ef645"},
@@ -5180,7 +5239,7 @@ files = [
     {file = "sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786"},
     {file = "sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32"},
 ]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
+markers = {main = "extra == \"kg\" or extra == \"all\" or extra == \"diary\" or extra == \"filetree\""}
 
 [[package]]
 name = "srsly"
@@ -5189,6 +5248,7 @@ description = "Modern high-performance serialization utilities for Python"
 optional = true
 python-versions = "<3.15,>=3.9"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "srsly-2.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c812302a9acfe171e82f680b7ad642014cd017380b2c678441b3da4fb513c498"},
     {file = "srsly-2.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91688edb1f49110870d2c215db2cf445f1763c14173698ead0818908c51fb2a1"},
@@ -5390,7 +5450,7 @@ files = [
     {file = "tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3"},
     {file = "tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d"},
 ]
-markers = {main = "extra == \"kg\" or extra == \"all\""}
+markers = {main = "extra == \"kg\" or extra == \"all\" or extra == \"diary\""}
 
 [package.extras]
 widechars = ["wcwidth"]
@@ -5419,6 +5479,7 @@ description = "A refreshing functional take on deep learning, compatible with yo
 optional = true
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "thinc-8.3.13-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:84fb50fe572a1860165f2e7a640c7cb70d43d6962366e69f643fa9a27e4a2127"},
     {file = "thinc-8.3.13-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3dac18a0fb0a42f711c2ce9c02cbb090385aecae92089aa17b9dfd808a542013"},
@@ -6028,6 +6089,7 @@ files = [
     {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
     {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
+markers = {main = "extra == \"diary\" or extra == \"all\" or extra == \"viz\" or extra == \"viz3d\""}
 
 [package.extras]
 brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
@@ -6130,6 +6192,7 @@ description = "A lightweight console printing and formatting toolkit"
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "wasabi-1.1.3-py3-none-any.whl", hash = "sha256:f76e16e8f7e79f8c4c8be49b4024ac725713ab10cd7f19350ad18a8e3f71728c"},
     {file = "wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878"},
@@ -6202,6 +6265,7 @@ description = "Weasel: A small and easy workflow system"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "weasel-1.0.0-py3-none-any.whl", hash = "sha256:89518acee027f49d743126c3502d35e6dd14f5768be5c37c9af47c171b6005cc"},
     {file = "weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc"},
@@ -6345,6 +6409,7 @@ description = "Module for decorators, wrappers and monkey patching."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"diary\" or extra == \"all\""
 files = [
     {file = "wrapt-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0bb2797048db0956348cb3058c33bc4184614f13231389cfbccc16a5d32780a7"},
     {file = "wrapt-2.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ce9f398f868d2b3b27aa2ea4de79645ef9077aeeac8dfc2814b0d542c6a2b87f"},
@@ -6442,9 +6507,11 @@ files = [
 dev = ["pytest", "setuptools"]
 
 [extras]
-all = ["PyQt5", "diary-kg", "doc-kg", "firecrawl-anydoc", "ftree-kg", "markdown", "param", "plotly", "pycode-kg", "pyvis", "pyvista", "pyvistaqt", "streamlit", "trame-vtk"]
+all = ["PyQt5", "diary-kg", "doc-kg", "firecrawl-anydoc", "ftree-kg", "markdown", "memory-kg", "param", "plotly", "pycode-kg", "pyvis", "pyvista", "pyvistaqt", "streamlit", "trame-vtk"]
+diary = ["diary-kg"]
+filetree = ["ftree-kg"]
 ingest = ["firecrawl-anydoc"]
-kg = ["diary-kg", "doc-kg", "ftree-kg", "pycode-kg"]
+kg = ["doc-kg", "memory-kg", "pycode-kg"]
 pi = ["llama-cpp-python"]
 qt = ["PyQt5"]
 viz = ["plotly", "pyvis", "streamlit"]
@@ -6454,4 +6521,4 @@ viz3d = ["PyQt5", "markdown", "param", "pyvista", "pyvistaqt", "trame-vtk"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.14"
-content-hash = "a8922ccdef9cba6a37d9dcf14141da57afa114cdfee7618069aa876bd3a0132b"
+content-hash = "3854fe16dad401f9fa8a4df9d2c755efa8428881794aacdce8a3c2c16c359f60"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,8 @@
-# kgrag - Knowledge Graph Builder for Python Codebases
+# pyproject.toml -- kg-rag package configuration (PEP 621)
 #
-# kgrag is a tool that builds searchable knowledge graphs from Python repositories.
-# It analyzes Python code to extract semantic relationships between modules, classes,
-# functions, and methods, creating a comprehensive graph representation that can be
-# queried using natural language.
+# kgrag is the orchestration layer for the KGRAG(tm) components. It builds and
+# queries searchable knowledge graphs across code, documents, and other corpora,
+# federating whatever KG modules happen to be installed.
 #
 # Key Features:
 # - AST-based code analysis with semantic understanding
@@ -13,229 +12,233 @@
 # - MCP (Model Context Protocol) server integration
 # - Streamlit-based web interface for exploration
 #
-# The tool is designed for developers who want to understand large codebases,
-# perform code analysis, or build AI-powered development tools.
-#
 # Author: Eric G. Suchanek, PhD
 #
-# Quick install (poetry) — recommended
-# -------------------------------------
-#   poetry install                               core orchestrator only
-#   poetry install --with dev                    core + dev tools (the group is optional)
-#   poetry install --extras "kg"                 core + PyPI KG adapters (pycode-kg, doc-kg, ftree-kg, diary-kg)
-#   poetry install --extras "viz"                core + 2D visualization (streamlit, pyvis, plotly)
-#   poetry install --extras "viz3d"              core + 3D visualization (pyvista, pyvistaqt, PyQt5)
-#   poetry install --extras "pi"                 core + llama-cpp-python (Raspberry Pi / local LLM)
-#   poetry install --extras "all"                everything except "pi" (needs a compiler)
-#   poetry install --extras "all" --with dev     everything + dev tools
+# Build system : Poetry 2.x with PEP 621 [project] table
 #
-# Git-only adapters (agent-kg, metabo-kg) — install via uv directly:
-#   uv add git+https://github.com/Flux-Frontiers/agent_kg.git
-#   uv add git+https://github.com/Flux-Frontiers/metabo_kg.git
+# Extras (user-facing features)
+# -----------------------------
+#   kg       the KG kinds most registries actually hold -- pycode-kg (code),
+#            doc-kg (doc, and every gutenberg KG), memory-kg (memory)
+#   diary    diary KGs (diary-kg -- pulls spacy, ~21M)
+#   filetree filetree KGs (ftree-kg)
+#   ingest   multi-format document ingestion, `kgrag ingest` (firecrawl-anydoc)
+#   viz      2-D visualization (streamlit, pyvis, plotly)
+#   viz2d    Qt surface for `kgrag viz2d` (PyQt5)
+#   qt       alias for viz2d, kept for older install instructions
+#   viz3d    3-D visualiser (pyvista, pyvistaqt, PyQt5)
+#   pi       llama-cpp-python embedder (Raspberry Pi / local GGUF)
+#   all      everything except `pi` -- see the note on that extra below
+#
+# Quick install (poetry)
+# ----------------------
+#   poetry install                            core orchestrator only
+#   poetry install --with dev                 core + dev tools (the group is optional)
+#   poetry install --extras "kg"              core + the common KG backends
+#   poetry install --extras "kg diary filetree"
+#                                             core + every PyPI KG backend
+#   poetry install --extras "viz"             core + 2-D visualization
+#   poetry install --extras "viz3d"           core + 3-D visualization
+#   poetry install --extras "pi"              core + llama-cpp-python
+#   poetry install --extras "all"             everything except "pi" (needs a compiler)
+#   poetry install --extras "all" --with dev  everything + dev tools
 #
 # Quick install (pip)
 # -------------------
-#   pip install -e "."                           core only
-#   pip install -e ".[kg]"                       core + PyPI KG adapters
-#   pip install -e ".[all]"                      everything (PyPI-resolvable)
+#   pip install -e "."                        core only
+#   pip install -e ".[kg]"                    core + the common KG backends
+#   pip install -e ".[kg,diary,filetree]"     core + every PyPI KG backend
+#   pip install -e ".[all]"                   everything except "pi"
 #
-# Universal CLI on PATH (uv) — recommended
-# ----------------------------------------
+# Git-only adapter backends (gutenberg-kg, metabo-kg) are not on PyPI and so
+# cannot be declared here. Install them separately when you register a KG of
+# that kind:
+#   uv add git+https://github.com/Flux-Frontiers/gutenberg_kg.git
+#   uv add git+https://github.com/Flux-Frontiers/metabo_kg.git
+#
+# Dev tooling lives in the optional Poetry `dev` group, NOT an extra, so it
+# stays out of published wheel metadata -- there is no `.[dev]` to pip-install.
+# (Fleet convention: extras are user-facing features, groups are repo tooling.
+# See kgrag_priv/docs/FLEET_STANDARDS.md.)
+#
+# Universal CLI on PATH (uv) -- recommended
+# -----------------------------------------
 #   uv tool install --editable ".[all]" --python 3.12
-#                                                install whole stack into isolated venv, kgrag* on PATH
-#   uv tool upgrade kg-rag                       pull in latest versions
-#   uv tool uninstall kg-rag                     remove
+#                                             whole stack in an isolated venv, kgrag* on PATH
+#   uv tool upgrade kg-rag                    pull in latest versions
+#   uv tool uninstall kg-rag                  remove
 #
 # Run tests
 # ---------
-#   pytest                                       uses [tool.pytest.ini_options]
+#   pytest                                    uses [tool.pytest.ini_options]
 #
 # MCP server
 # ----------
-#   kgrag-mcp                                    start the KGRAG MCP server
+#   kgrag-mcp                                 start the KGRAG MCP server
 #
 # Build KG indices (run inside each repo after code changes)
-# -----------------------------------------------------------
-#   pycodekg build --repo .                      rebuild code KG
-#   dockg build --repo .                         rebuild doc KG
-#   memorykg build                               rebuild memory KG
-
+# ----------------------------------------------------------
+#   pycodekg build --repo .                   rebuild code KG
+#   dockg build --repo .                      rebuild doc KG
+#   memorykg build                            rebuild memory KG
 
 [build-system]
 requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
+packages = [{ include = "kg_rag", from = "src" }]
+
+# ---------------------------------------------------------------------------
+# PEP 621 project metadata
+# ---------------------------------------------------------------------------
+[project]
 name = "kg-rag"
 version = "0.13.0"
 description = "Orchestration layer for the KGRAG(tm) components."
-authors = ["Eric G. Suchanek, PhD <suchanek@flux-frontiers.com>"]
-license = "Elastic-2.0"
 readme = "README.md"
-homepage = "https://github.com/Flux-Frontiers/KGRAG"
-repository = "https://github.com/Flux-Frontiers/KGRAG"
+license = "Elastic-2.0"
+authors = [
+    { name = "Eric G. Suchanek, PhD", email = "suchanek@flux-frontiers.com" }
+]
 keywords = ["knowledge-graph", "code-analysis", "ast", "lancedb", "sqlite", "semantic-search", "kgrag"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-packages = [
-  { include = "kg_rag", from = "src" },
-]
-
-# CPU-only torch on Linux: dev/CI here has no GPU, but the default PyPI linux
-# wheel bundles the full CUDA runtime (~2.7G of nvidia-* packages, ~700M of
-# triton) regardless. "explicit" priority means only packages naming this
-# source use it — nothing else is redirected off PyPI. This affects local/CI
-# installs only; it is not part of published wheel metadata, so `pip install
-# kg-rag` for a GPU user still resolves torch normally.
-#
-# Linux only: macOS/Windows torch builds are already CPU/MPS, and this index
-# publishes the macOS ones without the "+cpu" local version label, so locking
-# it globally leaves those platforms with no installable candidate.
-[[tool.poetry.source]]
-name = "pytorch-cpu"
-url = "https://download.pytorch.org/whl/cpu"
-priority = "explicit"
-
-[tool.poetry.dependencies]
-python = ">=3.12,<3.14"
+requires-python = ">=3.12,<3.14"
 # No lancedb here: KGRAG never imports it. Vector stores belong to the KG
 # modules, which declare their own; KGRAG only passes paths through and, in
 # `kgrag audit-lancedb`, looks for leftover directories on disk. Health checks
 # shell out to each module's CLI for the same reason (see cmd_health).
-# As of the doc-kg >=0.21.0 floor below, `kgrag[kg]` no longer drags lancedb in
-# transitively either: doc-kg moved it to an opt-in `[lancedb]` extra needed
-# only to read a pre-0.20.0 store. `kgrag audit-lancedb` is unaffected — it only
-# looks for leftover directories on disk and never imports the package.
-numpy = ">=1.24.0"
-# personal agent
-
-# from personal_agent
-transformers = ">=5.5.0,<6"
-sentence-transformers = "^5.2.0"
-safetensors = ">=0.5.0"
-
-torch = [
-    { markers = "sys_platform == 'linux'", version = ">=2.5.1", source = "pytorch-cpu" },
-    { markers = "sys_platform != 'linux'", version = ">=2.5.1" },
+# As of the doc-kg >=0.21.2 floor in the `kg` extra, `kgrag[kg]` no longer drags
+# lancedb in transitively either: doc-kg moved it to an opt-in `[lancedb]` extra
+# needed only to read a pre-0.20.0 store. `kgrag audit-lancedb` is unaffected --
+# it only looks for leftover directories on disk and never imports the package.
+dependencies = [
+    "click>=8.1.0",
+    # 0.13.0 was the original floor because it ships TEIEmbedder, which
+    # `embed_backend = "tei"` in src/kg_rag/embed.py imports directly. 0.13.1
+    # made SnapshotManager's `repo_root` a read-only property and broke every
+    # subclass that assigns it, so nothing in the fleet may resolve to it.
+    # 0.17.0 is the floor now: `kgrag ingest` needs kg_utils.ingest, which
+    # shipped to PyPI 2026-08-18. The anydoc import inside it stays guarded
+    # regardless, so staging .md/.txt/.rst still needs no extra.
+    "kgmodule-utils>=0.17.0",
+    # Upper-bounded: mcp 2.0 removed the low-level Server decorator API
+    # (`@server.list_tools()` / `@server.call_tool()`) that kg_rag.mcp_server
+    # uses. The Server class itself still imports under 2.0, so the failure
+    # surfaces as an AttributeError when _make_server() runs -- not at import --
+    # which makes it easy to miss. Lift this only alongside a port to the 2.x
+    # handler API.
+    "mcp>=1.0.0,<2",
+    "numpy>=1.24.0",
+    "pandas>=2.0.0",
+    "rich>=14.3.3,<15",
+    "safetensors>=0.5.0",
+    "sentence-transformers>=5.2.0,<6",
+    "torch>=2.5.1",
+    "transformers>=5.5.0,<6",
 ]
-streamlit = { version = ">=1.35.0", optional = true }
-pyvis = { version = ">=0.3.2", optional = true }
-pandas = ">=2.0.0"
-rich = "^14.3.3"
-click = ">=8.1.0"
-# Upper-bounded: mcp 2.0 removed the low-level Server decorator API
-# (`@server.list_tools()` / `@server.call_tool()`) that kg_rag.mcp_server uses.
-# The Server class itself still imports under 2.0, so the failure surfaces as an
-# AttributeError when _make_server() runs — not at import — which makes it easy
-# to miss. Lift this only alongside a port to the 2.x handler API.
-mcp = ">=1.0.0,<2"
-plotly = { version = ">=5.14.0", optional = true }
-# No `extras = ["jupyter"]`: that pulled the whole notebook stack
-# (jupyter-server-proxy -> jupyter-server, nbconvert -> mistune) for a renderer
-# nothing here drives from a notebook — viz3d is Qt-based via
-# `pyvistaqt.QtInteractor`, and no module sets a Jupyter backend. Re-add it only
-# alongside code that actually calls `pv.set_jupyter_backend()`.
-pyvista = { version = ">=0.44.0", optional = true }
-pyvistaqt = { version = ">=0.11.0", optional = true }
-PyQt5 = { version = ">=5.15.0", optional = true }
-param = { version = ">=2.0.0", optional = true }
-markdown = { version = ">=3.6", optional = true }
-trame-vtk = { version = ">=2.0.0", optional = true }
-spacy = {version = ">=3.7.0", optional = true}
-llama-cpp-python = { version = ">=0.3.0", optional = true }
-# Converts Word/PowerPoint/Excel/OpenDocument/RTF/EPUB/CSV/PDF to Markdown
-# for `kgrag ingest`. Optional: staging .md/.txt/.rst needs nothing extra,
-# and kg_utils.ingest imports it lazily.
-firecrawl-anydoc = { version = ">=0.1.9", optional = true }
 
-
-# our own adaptors (PyPI-only; git-only adapters installed separately via uv)
-# 0.13.0 was the original floor because it ships TEIEmbedder, which
-# `embed_backend = "tei"` in src/kg_rag/embed.py imports directly. 0.13.2 is
-# the floor now: 0.13.1 made SnapshotManager's `repo_root` a read-only property
-# and broke every subclass that assigns it, so nothing in the fleet declares a
-# floor that can resolve to it.
-# 0.17.0 is the floor now: `kgrag ingest` needs kg_utils.ingest, which shipped
-# to PyPI 2026-08-18. The anydoc import inside it stays guarded regardless, so
-# staging .md/.txt/.rst still needs no extra.
-kgmodule-utils = ">=0.17.0"
-pycode-kg = {version = ">=0.23.1", optional=true}
-doc-kg = {version = ">=0.21.2", optional=true}
-ftree-kg = {version = ">=0.13.0", optional=true}
-diary-kg  = {version = ">=0.97.0", optional = true}
-
-
-[tool.poetry.extras]
-viz = ["streamlit", "pyvis", "plotly"]
-viz2d = ["PyQt5"]
-qt = ["PyQt5"]
-viz3d = ["pyvista", "pyvistaqt", "PyQt5", "param", "markdown", "trame-vtk"]
-kg = ["pycode-kg", "ftree-kg", "doc-kg", "diary-kg"]
-# Multi-format document ingestion: `kgrag ingest`.
-ingest = ["firecrawl-anydoc"]
-pi = ["llama-cpp-python"]
+[project.optional-dependencies]
+# KG adapter backends. Every adapter in kg_rag.adapters imports its backend
+# lazily inside a method and gates on is_available(), so the orchestrator runs
+# with none of these installed -- it simply has nothing it can query. Install
+# the ones matching the KG kinds you actually register.
+#
+# `kg` carries the three that a typical registry leans on:
+#   pycode-kg   kind=code
+#   doc-kg      kind=doc AND kind=gutenberg -- the gutenberg adapter queries
+#               through DocKG, so a 241-book corpus needs doc-kg and nothing
+#               else. (gutenberg-kg itself is only for corpus_status/snapshot,
+#               which nothing in kg_rag calls, and it is not on PyPI anyway.)
+#   memory-kg   kind=memory
+# diary-kg and ftree-kg moved to their own extras below rather than staying
+# here: they back kinds most registries never hold, and diary-kg pulls spacy
+# (~21M) for a backend that then sits unused.
+kg = [
+    "doc-kg>=0.21.2",
+    "memory-kg>=0.7.0",
+    "pycode-kg>=0.23.1",
+]
+diary = [
+    "diary-kg>=0.97.0",
+]
+filetree = [
+    "ftree-kg>=0.13.0",
+]
+# Multi-format document ingestion: `kgrag ingest`. Converts Word / PowerPoint /
+# Excel / OpenDocument / RTF / EPUB / CSV / PDF to Markdown. Optional because
+# staging .md/.txt/.rst needs nothing extra and kg_utils.ingest imports it
+# lazily.
+ingest = [
+    "firecrawl-anydoc>=0.1.9",
+]
+viz = [
+    "plotly>=5.14.0",
+    "pyvis>=0.3.2",
+    "streamlit>=1.35.0",
+]
+viz2d = [
+    "PyQt5>=5.15.0",
+]
+qt = [
+    "PyQt5>=5.15.0",
+]
+viz3d = [
+    "markdown>=3.6",
+    "param>=2.0.0",
+    "PyQt5>=5.15.0",
+    # No `[jupyter]`: that pulled the whole notebook stack (jupyter-server-proxy
+    # -> jupyter-server, nbconvert -> mistune) for a renderer nothing here drives
+    # from a notebook -- viz3d is Qt-based via `pyvistaqt.QtInteractor`, and no
+    # module sets a Jupyter backend. Re-add it only alongside code that actually
+    # calls `pv.set_jupyter_backend()`.
+    "pyvista>=0.44.0",
+    "pyvistaqt>=0.11.0",
+    "trame-vtk>=2.0.0",
+]
+pi = [
+    "llama-cpp-python>=0.3.0",
+]
 # Deliberately excludes "pi": llama-cpp-python has no wheel for every platform
 # and falls back to a source build, so folding it in here would make `--all-extras`
-# require a compiler toolchain.  Install it explicitly with --extras "pi".
+# require a compiler toolchain. Install it explicitly with --extras "pi".
+#
+# Constraints here must match the per-extra ones above character for character.
+# Re-listing a package under a *different* constraint makes it a second
+# declaration under an overlapping marker, which poetry reports as "Duplicate
+# dependencies ... Different requirements found" and resolves by restarting the
+# whole lock with an override -- pathologically slow once a few packages do it.
 all = [
-  "pycode-kg", "ftree-kg", "doc-kg", "diary-kg",
-  "firecrawl-anydoc",
-  "streamlit", "pyvis", "plotly",
-  "pyvista", "pyvistaqt", "PyQt5", "param", "markdown", "trame-vtk",
+    "diary-kg>=0.97.0",
+    "doc-kg>=0.21.2",
+    "ftree-kg>=0.13.0",
+    "memory-kg>=0.7.0",
+    "pycode-kg>=0.23.1",
+    "firecrawl-anydoc>=0.1.9",
+    "plotly>=5.14.0",
+    "pyvis>=0.3.2",
+    "streamlit>=1.35.0",
+    "markdown>=3.6",
+    "param>=2.0.0",
+    "PyQt5>=5.15.0",
+    "pyvista>=0.44.0",
+    "pyvistaqt>=0.11.0",
+    "trame-vtk>=2.0.0",
 ]
 
-[tool.poetry.group.qt]
-optional = true
+[project.urls]
+Homepage   = "https://github.com/Flux-Frontiers/KGRAG"
+Repository = "https://github.com/Flux-Frontiers/KGRAG"
 
-[tool.poetry.group.qt.dependencies]
-PyQt5 = ">=5.15.0"
-
-[tool.poetry.group.viz3d]
-optional = true
-
-[tool.poetry.group.viz3d.dependencies]
-pyvista = { version = ">=0.44.0" }
-pyvistaqt = ">=0.11.0"
-PyQt5 = ">=5.15.0"
-param = ">=2.0.0"
-markdown = ">=3.6"
-trame-vtk = ">=2.0.0"
-
-[tool.poetry.group.dev]
-optional = true
-
-[tool.poetry.group.dev.dependencies]
-pytest = ">=9.0.3"
-pytest-cov = ">=5.0.0"
-# Capped below 0.16 deliberately, matching `kgmodule-utils`. 0.16 began
-# formatting Python inside Markdown code blocks, which rewrites hand-aligned
-# examples in 11 files here — `docs/ADAPTER_SPEC.md`, `docs/MCP.md`,
-# `articles/kgrag_medium.md` and the rest — and expanded the default rule set.
-# The floor was unbounded, so the lock had already resolved 0.16.3 and
-# `ruff format --check .` fails on `main` today, independent of any branch.
-# Both are upgrades to adopt on purpose, not side effects a lock regeneration
-# should smuggle in. Lift the cap in its own change, together with the
-# reformatting it implies.
-ruff = ">=0.4.0,<0.16"
-ty = ">=0.0.44,<0.0.45"
-pre-commit = "^4.5.1"
-detect-secrets = "^1.5.0"
-pdoc = ">=14.0.0"
-pip-audit = "^2.10.0"
-# The adapters are optional at runtime (the `kg` extra) but not optional to
-# test: an adapter's whole job is constructing a real DocKG/PyCodeKG with the
-# right arguments, and a mocked-out import cannot show that it does. Installed
-# here so the suite exercises the real classes. The marginal cost is small —
-# sentence-transformers already pulls the torch/transformers stack.
-pycode-kg = ">=0.23.1"
-doc-kg = ">=0.21.2"
-
-
-[tool.poetry.scripts]
+[project.scripts]
 kgrag              = "kg_rag.cli.main:cli"
 kgrag-mcp          = "kg_rag.mcp_server:main"
 kgrag-register     = "kg_rag.cli.cmd_registry:register"
@@ -251,6 +254,81 @@ kgrag-analyze      = "kg_rag.cli.cmd_analyze:analyze"
 kgrag-viz          = "kg_rag.cli.cmd_viz:viz"
 kgrag-viz2d        = "kg_rag.cli.cmd_viz2d:viz2d"
 
+# ---------------------------------------------------------------------------
+# Poetry-specific dependency enrichment and groups
+# ---------------------------------------------------------------------------
+# CPU-only torch on Linux: dev/CI here has no GPU, but the default PyPI linux
+# wheel bundles the full CUDA runtime (~2.7G of nvidia-* packages, ~700M of
+# triton) regardless. "explicit" priority means only packages naming this
+# source use it -- nothing else is redirected off PyPI. This affects local/CI
+# installs only; it is not part of published wheel metadata, so `pip install
+# kg-rag` for a GPU user still resolves torch normally.
+#
+# Linux only: macOS/Windows torch builds are already CPU/MPS, and this index
+# publishes the macOS ones without the "+cpu" local version label, so locking
+# it globally leaves those platforms with no installable candidate.
+[[tool.poetry.source]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+priority = "explicit"
+
+# The version constraint lives in [project.dependencies]; this block only adds
+# the source routing poetry needs and PEP 621 cannot express.
+[tool.poetry.dependencies]
+torch = [
+    { markers = "sys_platform == 'linux'", source = "pytorch-cpu" },
+    { markers = "sys_platform != 'linux'" },
+]
+
+[tool.poetry.group.qt]
+optional = true
+
+[tool.poetry.group.qt.dependencies]
+PyQt5 = ">=5.15.0"
+
+[tool.poetry.group.viz3d]
+optional = true
+
+[tool.poetry.group.viz3d.dependencies]
+pyvista = ">=0.44.0"
+pyvistaqt = ">=0.11.0"
+PyQt5 = ">=5.15.0"
+param = ">=2.0.0"
+markdown = ">=3.6"
+trame-vtk = ">=2.0.0"
+
+[tool.poetry.group.dev]
+optional = true
+
+[tool.poetry.group.dev.dependencies]
+pytest = ">=9.0.3"
+pytest-cov = ">=5.0.0"
+# Capped below 0.16 deliberately, matching `kgmodule-utils`. 0.16 began
+# formatting Python inside Markdown code blocks, which rewrites hand-aligned
+# examples in 11 files here -- `docs/ADAPTER_SPEC.md`, `docs/MCP.md`,
+# `articles/kgrag_medium.md` and the rest -- and expanded the default rule set.
+# The floor was unbounded, so the lock had already resolved 0.16.3 and
+# `ruff format --check .` fails on `main` today, independent of any branch.
+# Both are upgrades to adopt on purpose, not side effects a lock regeneration
+# should smuggle in. Lift the cap in its own change, together with the
+# reformatting it implies.
+ruff = ">=0.4.0,<0.16"
+ty = ">=0.0.44,<0.0.45"
+pre-commit = "^4.5.1"
+detect-secrets = "^1.5.0"
+pdoc = ">=14.0.0"
+pip-audit = "^2.10.0"
+# The adapters are optional at runtime (the `kg` extra) but not optional to
+# test: an adapter's whole job is constructing a real DocKG/PyCodeKG with the
+# right arguments, and a mocked-out import cannot show that it does. Installed
+# here so the suite exercises the real classes. The marginal cost is small --
+# sentence-transformers already pulls the torch/transformers stack.
+pycode-kg = ">=0.23.1"
+doc-kg = ">=0.21.2"
+
+# ---------------------------------------------------------------------------
+# Tool configuration
+# ---------------------------------------------------------------------------
 [tool.ruff]
 line-length = 100
 target-version = "py312"
@@ -279,6 +357,9 @@ unresolved-import = "ignore"
 testpaths = ["tests"]
 addopts = "-v --tb=short"
 
+# ---------------------------------------------------------------------------
+# KG index configuration
+# ---------------------------------------------------------------------------
 [tool.pycodekg]
 # Directories to include in the knowledge graph build and analysis.
 # When unset, all directories are indexed.
@@ -296,13 +377,29 @@ exclude = ["bundles", "dist", "books"]
 exclude = ["bundles", "dist", "books"]
 
 [tool.memorykg]
-# Claude_T self-knowledge corpus — architecture, identity, and stack docs.
-# Built with: memorykg build --source docs/ --extra CLAUDE_T_IDENTITY.md,CLAUDE.md,README.md
+# Claude_T self-knowledge corpus -- architecture, identity, and stack docs.
+# Rebuild after any change to the identity documents:
+#   memorykg build --repo .
 # Registered with: kgrag register --name claude_t_self --path .memorykg/
-source = ["docs"]
-extra = ["CLAUDE_T_IDENTITY.md", "CLAUDE.md", "README.md", "PORTABLE_KNOWLEDGE_VISION.md", "AGENT_PERSPECTIVE.md"]
-output = ".memorykg"
-corpus_name = "claude_t_self"
+#
+# `exclude` is the only key memory-kg reads (see memory_kg/config.py). The
+# previous block declared source/extra/output/corpus_name, which nothing reads,
+# and documented `--source` / `--extra` flags the CLI no longer has -- so the
+# exclusions below had to be repeated by hand as --exclude-dir on every build.
+# Everything not listed here is corpus: the identity documents at the repo root
+# and the whole of docs/.
+exclude = [
+    ".venv",
+    "articles",
+    "books",
+    "bundles",
+    "dist",
+    "patents",
+    "pepys",
+    "scripts",
+    "src",
+    "tests",
+]
 
 [tool.poe.tasks.docs]
 help = "Generate project documentation and user guide PDFs"
@@ -330,7 +427,7 @@ embed_backend = "sentence_transformers"
 #
 # tei_endpoint    = "http://localhost:8080"  # or the KG_EMBED_ENDPOINT env var
 # tei_dim         = 384    # skips the one-off startup probe; must match the served model
-# tei_model       = ""     # informational label only — the server chooses the model
+# tei_model       = ""     # informational label only -- the server chooses the model
 # tei_api_key     = ""     # or the KG_EMBED_API_KEY env var; stock TEI needs none
 # tei_timeout     = 120.0
 # tei_max_retries = 3      # retries 429/502/503/504 and transport errors

--- a/src/kg_rag/adapters/memory_adapter.py
+++ b/src/kg_rag/adapters/memory_adapter.py
@@ -34,11 +34,15 @@ class MemoryKGAdapter(KGAdapter):
             ) from exc
         entry = self.entry
         sqlite = str(entry.sqlite_path) if entry.sqlite_path else None
-        lancedb = str(entry.lancedb_path) if entry.lancedb_path else None
+        # No lancedb_dir: memory-kg 0.7.0 dropped the parameter when it moved to
+        # sqlite-vec, so passing it raises TypeError. None lets memory-kg derive
+        # the sidecar next to the graph, which is right for the default layout;
+        # an explicit path is required only when the store lives elsewhere.
+        vectors = str(entry.vectors_path) if entry.vectors_path else None
         self._kg = MemoryKG(
             corpus_root=str(entry.repo_path),
             db_path=sqlite or str(entry.repo_path / ".memorykg" / "graph.sqlite"),
-            lancedb_dir=lancedb or str(entry.repo_path / ".memorykg" / "lancedb"),
+            vectors_path=vectors,
             embedder=self._embedder,
         )
 


### PR DESCRIPTION
## Why

Two questions drove this: do we really need to install the adapter backends, and which ones should we install? Answering the second turned up a KG that could never be queried.

## PEP 621

`pyproject.toml` now uses the `[project]` layout that `gutenberg_kg` uses. Metadata, extras, URLs and console scripts moved to `[project]`, `[project.optional-dependencies]`, `[project.urls]` and `[project.scripts]`. `[tool.poetry]` keeps only `packages`, the dependency groups, and the `torch` source enrichment PEP 621 cannot express:

```toml
[tool.poetry.dependencies]
torch = [
    { markers = "sys_platform == 'linux'", source = "pytorch-cpu" },
    { markers = "sys_platform != 'linux'" },
]
```

All 14 console scripts, `kgrag-mcp` included, came through unchanged. The regenerated lock installs an identical package set at identical versions.

## Extras

None of the adapter backends are needed to *run* KGRAG -- every adapter in `kg_rag.adapters` imports its backend lazily inside a method and gates on `is_available()`, so the CLI and MCP server work with none installed. What you lose is the ability to query. Nor is size the reason to trim: in a 1.0 GB tool env the four backends account for ~1.6 MB. The weight is torch (489M) and transformers (50M) in core.

So the right question is which KG *kinds* a registry actually holds. In a representative one:

| kind | entries | backend |
|---|---|---|
| gutenberg | 241 | doc-kg (queries through `DocKG`) |
| code | 6 | pycode-kg |
| doc | 5 | doc-kg |
| memory | 1 | **memory-kg -- declared nowhere** |

- **`memory-kg` added to `kg` and `all`.** A registered `kind=memory` KG could never be queried on a stock install; `kgrag query --kind memory` reported "No available KGs to query" however the KG was built.
- **`diary-kg` and `ftree-kg` moved out of `kg`** into new `diary` and `filetree` extras. They back kinds most registries never hold, and `diary-kg` pulls spacy (~21M) for a backend that then sits unused.

`kg` now carries the three a typical registry leans on. `all` is unchanged and still installs every backend.

> [!WARNING]
> **Breaking** for anyone relying on `kg-rag[kg]` for diary or filetree support. Use `kg-rag[kg,diary,filetree]`.

`gutenberg-kg` is deliberately still absent: gutenberg KGs query through `DocKG`, and the only code needing `gutenberg_kg` itself is `corpus_status`/snapshot in `gutenberg_adapter`, which nothing in `kg_rag` calls. It is not on PyPI either.

## MemoryKGAdapter

Declaring `memory-kg` was not enough. The adapter passed `lancedb_dir=` to `MemoryKG.__init__`, a parameter memory-kg dropped in 0.7.0 when it moved to sqlite-vec:

```
TypeError: MemoryKG.__init__() got an unexpected keyword argument 'lancedb_dir'
```

It now passes `vectors_path=`, left `None` for the default layout so memory-kg derives the sidecar beside the graph -- the idiom `DocKGAdapter` already used.

An `inspect.signature().bind()` sweep over all 16 backend construction sites in `kg_rag.adapters` -- positionals, keywords and arity together -- found **15 bind cleanly**. The one failure outside this fix is `MetaKGAdapter`, which has the same `lancedb_dir` -> `vectors_path` drift from metabo-kg 0.10.0. Left alone deliberately: metabo-kg is a template here, is not on PyPI, and backs no registered KG. It is latent, not live.

## Also

- **Dropped `spacy`**, marked `optional = true` but listed in no extra, so no install could select it, and unimported in `src/` and `tests/`. Still arrives transitively via `diary-kg`.
- **Rewrote `[tool.memorykg]`** to the one key memory-kg reads. It declared `source`/`extra`/`output`/`corpus_name`, read by nothing, and documented `--source`/`--extra` flags the CLI no longer has -- so its exclusions had to be retyped as `--exclude-dir` on every build. Rebuilding `claude_t_self` is now `memorykg build --repo .`.
- **README install block corrected** -- it claimed `[kg]` supplied FTreeKG and referenced a `kgdeps` Poetry group that does not exist.

## Verification

- `poetry check` passes
- `poetry lock` resolves the same package set at the same versions (only `memory-kg` added, plus an inert `nvidia-cufile` entry that no torch entry requires; the linux `2.13.0+cpu` routing is unchanged)
- 516 tests pass; `ruff check` clean; pre-commit `ruff`/`ty`/`pytest`/`detect-secrets` all pass
- Built wheel carries the expected `Provides-Extra` and `Requires-Dist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
