### PR TITLE
fix(pre-commit): call venv tools directly instead of poetry run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,13 +35,13 @@ repos:
     hooks:
       - id: ty
         name: ty
-        entry: poetry run ty check src/
+        entry: .venv/bin/ty check src/ --python .venv
         language: system
         pass_filenames: false
         always_run: true
       - id: pytest
         name: pytest
-        entry: poetry run pytest --tb=short -q
+        entry: .venv/bin/pytest --tb=short -q
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
`poetry run` resolves against whichever environment the calling shell advertises, so an inherited `VIRTUAL_ENV` from a different repo silently redirected these hooks. The failures never looked like environment problems — `Command not found: ty`, or diagnostics claiming `numpy` could not be resolved. It also put `poetry` on the critical path for every commit and push.

Entries now call `.venv/bin/<tool>`. For `ty` that is not sufficient alone — it resolves site-packages from `VIRTUAL_ENV` regardless of which binary started it — so `--python .venv` pins the environment too.

**Verified** by running the full hook set with `VIRTUAL_ENV` deliberately pointed at another repo's venv and `PATH` stripped to `/usr/bin:/bin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)