### PR TITLE
fix(changelog): normalise release-heading separators to one hyphen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1660,7 +1660,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raised when subclasses (e.g. FTreeKG) hydrate `snap.metrics` as a dataclass rather
   than a dict.
 
-## [0.3.3] — 2026-03-18
+## [0.3.3] - 2026-03-18
 
 ### Added
 - `src/kg_rag/cli/cmd_hooks.py` — new `kgrag install-hooks` CLI command that
@@ -1682,7 +1682,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cuda-pathfinder` 1.4.2 → 1.4.3. Removed transitive deps no longer needed:
   `typer`, `shellingham`, `annotated-doc`.
 
-## [0.3.1] — 2026-03-18
+## [0.3.1] - 2026-03-18
 
 ### Added
 - `analysis/kgrag_analysis_20260318.md` — fresh architectural analysis report
@@ -1791,7 +1791,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with timezone-aware `datetime.now(UTC)` to avoid `DeprecationWarning` on
   Python 3.12+ and ensure correct UTC semantics.
 
-## [0.2.0] — 2026-03-12
+## [0.2.0] - 2026-03-12
 
 ### Added
 - `kgrag init` command (`src/kg_rag/cli/cmd_init.py`) — one-shot initialisation


### PR DESCRIPTION
## Summary

`fleet_audit.py` parses release headings as `## [x.y.z] - YYYY-MM-DD`, the form Keep a Changelog specifies. The headings here used a different separator, so they matched nothing and this repo's releases were **absent from every fleet audit that has ever run**. There was no error: `parse_changelog_releases` simply returned fewer releases, and the version column stayed populated because it falls back to `CITATION.cff`.

Fleet-wide the guard turned up 18 invisible releases across four repos (`quiltwright` 8, `corpus_pepys` 6, `kgrag` 3, `Metabo_kg` 1). The parser fix and the new `check_changelog_headings` are in Flux-Frontiers/kgrag_priv#26; the standard is recorded in `FLEET_STANDARDS.md`.

Separator only. An anchored substitution on release-heading lines; nothing else in the CHANGELOG changed, as the diff shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
