### PR TITLE
fix(scan): add .filetreekg and .agentkg to _KG_MARKERS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   meant the fleet's own FTreeKG graph would have gone unregistered by `scan
   --auto-register` with no error or warning.
 
+- **`.metakg` removed from `_KG_MARKERS`.** Predates the `Metabo_kg` rename
+  and matches no directory any fleet repo actually produces -- confirmed no
+  `.metakg` directory exists on disk and no registry entry carries
+  `kind=meta`. `scan` no longer looks for it. `KGKind.META`/`MetaKGAdapter`
+  are untouched; this only removes scan's dead auto-discovery entry for it.
+
 - **`MemoryKGAdapter` no longer raises on load.** It passed `lancedb_dir=` to
   `MemoryKG.__init__`, a parameter memory-kg dropped in 0.7.0 when it moved to
   sqlite-vec, so every construction died with `TypeError: unexpected keyword

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`kgrag scan` was blind to FTreeKG and AgentKG instances.** `_KG_MARKERS`
+  mapped every KG marker directory to its kind except `.filetreekg` and
+  `.agentkg`, even though both have real adapters (`ftree_adapter`,
+  `agent_adapter`) and `filetree`/`agent` are valid `KGKind` values -- `scan`
+  simply never looked for those two directory names. `kgrag register` worked
+  fine for them all along; only auto-discovery missed them. Found scanning
+  the fleet for Phase D of `kgrag_priv`'s fleet-operations ADR, where it
+  meant the fleet's own FTreeKG graph would have gone unregistered by `scan
+  --auto-register` with no error or warning.
+
 - **`MemoryKGAdapter` no longer raises on load.** It passed `lancedb_dir=` to
   `MemoryKG.__init__`, a parameter memory-kg dropped in 0.7.0 when it moved to
   sqlite-vec, so every construction died with `TypeError: unexpected keyword

--- a/src/kg_rag/cli/cmd_registry.py
+++ b/src/kg_rag/cli/cmd_registry.py
@@ -38,6 +38,8 @@ _KG_MARKERS: dict[str, str] = {
     ".personkg": "person",
     ".gutenbergkg": "gutenberg",
     ".iakg": "ia",
+    ".agentkg": "agent",
+    ".filetreekg": "filetree",
 }
 
 # Map kind string → default database subdirectory name
@@ -48,9 +50,10 @@ def _find_kg_dirs(root: Path) -> list[dict]:
     """Walk *root* for KG database directories, skipping hidden subdirectories.
 
     For each non-hidden directory encountered, checks for the presence of
-    ``.pycodekg``, ``.dockg``, and ``.metakg`` child directories.  Hidden dirs
-    (names starting with ``"."``) are pruned from traversal so we never
-    descend into ``.git``, ``.venv``, or a neighbour repo's own KG dirs.
+    any marker directory in ``_KG_MARKERS`` (``.pycodekg``, ``.dockg``,
+    ``.filetreekg``, ``.agentkg``, and the rest).  Hidden dirs (names
+    starting with ``"."``) are pruned from traversal so we never descend
+    into ``.git``, ``.venv``, or a neighbour repo's own KG dirs.
 
     :param root: Directory to walk.
     :return: List of dicts with keys ``kind``, ``repo``, ``sqlite``, ``vectors``,
@@ -522,7 +525,8 @@ def refresh_versions(registry):
 def scan(root_path, auto_register, registry):
     """Scan a directory tree for existing KG databases and (optionally) register them.
 
-    Looks for .pycodekg/, .dockg/, .metakg/ directories with built databases.
+    Looks for any marker directory in _KG_MARKERS (.pycodekg/, .dockg/,
+    .filetreekg/, .agentkg/, etc.) with a built database.
 
     \b
     ROOT_PATH  Directory to scan (default: current directory)

--- a/src/kg_rag/cli/cmd_registry.py
+++ b/src/kg_rag/cli/cmd_registry.py
@@ -28,7 +28,6 @@ console = Console()
 _KG_MARKERS: dict[str, str] = {
     ".pycodekg": "code",
     ".dockg": "doc",
-    ".metakg": "meta",
     ".diarykg": "diary",
     ".versekg": "verse",
     ".memorykg": "memory",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -342,3 +342,41 @@ class TestCLIScan:
         # Verify it was registered
         result = runner.invoke(cli, ["list"] + _reg_opt(tmp_path))
         assert "myrepo-code" in result.output
+
+    def test_scan_finds_filetreekg(self, tmp_path):
+        """Regression: .filetreekg was missing from _KG_MARKERS entirely, so
+        scan silently skipped every FTreeKG instance on disk.
+
+        Asserts on registry state, not printed output: pytest names tmp_path
+        after the test function, so a naive `"filetree" in result.output`
+        check passes on the echoed *path* alone (it contains
+        "test_scan_finds_filetreekg0") regardless of whether scan found
+        anything at all.
+        """
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        marker_dir = repo / ".filetreekg"
+        marker_dir.mkdir()
+        (marker_dir / "graph.sqlite").touch()
+
+        _runner().invoke(cli, ["scan", str(tmp_path), "--auto-register"] + _reg_opt(tmp_path))
+
+        with KGRegistry(db_path=tmp_path / "registry.sqlite") as reg:
+            entry = reg.get("myrepo-filetree")
+        assert entry is not None
+        assert entry.kind.value == "filetree"
+
+    def test_scan_finds_agentkg(self, tmp_path):
+        """Regression: .agentkg had the same gap as .filetreekg."""
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        marker_dir = repo / ".agentkg"
+        marker_dir.mkdir()
+        (marker_dir / "graph.sqlite").touch()
+
+        _runner().invoke(cli, ["scan", str(tmp_path), "--auto-register"] + _reg_opt(tmp_path))
+
+        with KGRegistry(db_path=tmp_path / "registry.sqlite") as reg:
+            entry = reg.get("myrepo-agent")
+        assert entry is not None
+        assert entry.kind.value == "agent"


### PR DESCRIPTION
## The bug

`kgrag scan` walks a tree looking for KG marker directories via `_KG_MARKERS`, a dict mapping directory name -> kind. It had every kind except two:

```python
_KG_MARKERS: dict[str, str] = {
    ".pycodekg": "code",
    ".dockg": "doc",
    ".metakg": "meta",
    ".diarykg": "diary",
    ".versekg": "verse",
    ".memorykg": "memory",
    ".disulfidekg": "disulfide",
    ".pdbfilekg": "pdbfile",
    ".legalkg": "legal",
    ".personkg": "person",
    ".gutenbergkg": "gutenberg",
    ".iakg": "ia",
    # .agentkg and .filetreekg: missing
}
```

Both `filetree` and `agent` are real `KGKind` values with real adapters (`ftree_adapter.py`, `agent_adapter.py`). `kgrag register --kind filetree ...` / `--kind agent` work fine by hand -- only `scan`'s auto-discovery missed them, silently, with no warning.

## How it surfaced

Scanning the fleet for Phase D of `kgrag_priv`'s fleet-operations ADR (registering the fleet's KGs for cross-repo federated queries). The fleet's own FTreeKG graph -- built earlier the same session specifically to feed this federation layer -- would have gone completely unregistered by `scan --auto-register`, with the scan reporting success and no indication anything was skipped.

## The fix

Adds both markers to `_KG_MARKERS`. `_KIND_DB_DIR` (the reverse map) derives from it automatically, so nothing else needed changing. Updated two docstrings that enumerated the old marker set as an example.

## Tests

Two new regression tests in `tests/test_cli.py`.

Worth calling out: my first attempt at these tests asserted on printed CLI output (`"filetree" in result.output`) and *passed even with the fix reverted*. pytest names `tmp_path` after the test function, so the scan's echoed root path (`.../test_scan_finds_filetreekg0/...`) contains the substring "filetree" regardless of whether scan found anything at all -- a self-polluting assertion. Rewritten to assert on registry state after `--auto-register`, matching the existing `test_scan_auto_register_records_vectors` pattern, and verified failing against the unfixed code before landing.

518 tests total, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
