### PR TITLE
feat(scope): time_range -- time as a federation axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`QueryScope.time_range` — time becomes a federation axis.** A federated
+  query can now be scoped to a window as well as a subtree and node kinds:
+  `QueryScope(time_range=("2026-04-01", "2026-04-30"))`. Either bound may be
+  `None` for an open-ended window. Filtering reads the shared temporal
+  contract in `kg_utils.temporal`, so precision is honoured — a node dated
+  `"1876"` overlaps any window touching that year, and a node's *occurrence*
+  outranks when it was recorded.
+
+  This fills the slot `metadata_eq` had been reserving since 0.10.0, and it is
+  what makes "what happened in April" answerable across diary, memory,
+  conversation, filesystem and snapshot KGs in one call rather than per-repo.
+
+  **Undated results are rejected when `time_range` is set** — the opposite of
+  how an unknown `kind` is treated, and deliberately so. A result with no
+  temporal metadata cannot answer "when", and admitting it would make the
+  window meaningless: a code KG would return every function for every window.
+  The practical consequence is that a module which has not yet adopted the
+  temporal contract drops out of time-scoped queries entirely. That is the
+  honest outcome rather than a silent one.
+
+  `CrossHit` and `CrossSnippet` gained a `metadata` field (defaulting to `{}`)
+  so the orchestrator's post-filter has something to read for adapters without
+  scope pushdown. Without it, time scoping would have silently matched nothing
+  on the degradation path — the failure mode the class was written to avoid.
+  Adapters populate it as they adopt the contract; until an adapter does, its
+  hits count as undated.
+
+  Requires `kgmodule-utils>=0.18.0`, and the floor moves with it.
+
 - **`memory-kg` is now a declared dependency** (the `kg` and `all` extras).
   It was in no extra at all, so a registered `kind=memory` KG could never be
   queried through KGRAG on a stock install -- `kgrag query --kind memory`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`kgrag timeline` — chronological cross-KG query.** The point at which the
+  temporal contract becomes something a person can ask a question with. A diary
+  entry, a book publication, a photograph and a conversation topic sort into
+  one sequence, because every adopting module writes the same three keys.
+
+  Ordered by *when*, not by relevance — that is what separates it from
+  `kgrag query --from`. `--from` / `--to` accept any ISO precision, and the
+  precision is meaningful: `--from 1876` means the whole of 1876, not its first
+  midnight.
+
+  Three things it is careful not to lie about:
+
+  - **Precision is shown, never padded.** A book dated `1876` renders as
+    `1876`, not as a false midnight on 1 January.
+  - **Only an explicit `occurred_end` becomes a range.** A year-precision span
+    *implies* an end of 31 December, and printing `1876 → 1876-12-31` would
+    claim a bound the source never wrote.
+  - **A recorded-only date is marked `~`.** It says when something was written
+    down, not when it happened, and a timeline showing the two identically is
+    lying about one of them.
+
+  Undated hits are counted and reported rather than silently dropped — a module
+  that has not adopted the contract would otherwise look like a module with
+  nothing to say.
+
 - **`QueryScope.time_range` — time becomes a federation axis.** A federated
   query can now be scoped to a window as well as a subtree and node kinds:
   `QueryScope(time_range=("2026-04-01", "2026-04-30"))`. Either bound may be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Adapters populate it as they adopt the contract; until an adapter does, its
   hits count as undated.
 
-  Requires `kgmodule-utils>=0.18.0`, and the floor moves with it.
+  Requires `kgmodule-utils>=0.18.0`, and the floor moves with it. That release
+  also fixes the reason this could not have worked before: `GraphStore` was
+  dropping node metadata on write, so a module could attach `occurred_start`
+  to a node and no query would ever see it.
+
+- **Adapters carry node metadata into hits** via a new `node_metadata()` helper
+  in `kg_rag.adapters.base`, wired into the doc, gutenberg, diary, memory and
+  filetree adapters. It reads either a nested `metadata` mapping or the
+  temporal keys flattened onto the node, since backends differ, and returns a
+  copy so a hit cannot mutate the backend's node.
+
+  Without this the `time_range` scope would have been inert in practice:
+  hits arrived with empty metadata, so every result counted as undated and
+  a time-scoped query returned nothing at all.
 
 - **`memory-kg` is now a declared dependency** (the `kg` and `all` extras).
   It was in no extra at all, so a registered `kind=memory` KG could never be

--- a/poetry.lock
+++ b/poetry.lock
@@ -949,7 +949,6 @@ nvidia-cuda-cupti = {version = "==13.0.85.*", optional = true, markers = "(sys_p
 nvidia-cuda-nvrtc = {version = "==13.0.88.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and (extra == \"cublas\" or extra == \"nvrtc\")"}
 nvidia-cuda-runtime = {version = "==13.0.96.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cudart\""}
 nvidia-cufft = {version = "==12.0.0.61.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cufft\""}
-nvidia-cufile = {version = "==1.15.1.6.*", optional = true, markers = "sys_platform == \"linux\" and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cufile\""}
 nvidia-curand = {version = "==10.4.0.35.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"curand\""}
 nvidia-cusolver = {version = "==12.0.4.66.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cusolver\""}
 nvidia-cusparse = {version = "==12.6.3.3.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and (extra == \"cusolver\" or extra == \"cusparse\")"}
@@ -1436,20 +1435,20 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "ftree-kg"
-version = "0.13.0"
+version = "0.14.0"
 description = "KGModule for file tree knowledge graphs"
 optional = true
 python-versions = "<3.14,>=3.12"
 groups = ["main"]
 markers = "extra == \"filetree\" or extra == \"all\""
 files = [
-    {file = "ftree_kg-0.13.0-py3-none-any.whl", hash = "sha256:d523376dec945ab10da07fee8bb3251a6c6dc65add17679b91109df4abe4a897"},
-    {file = "ftree_kg-0.13.0.tar.gz", hash = "sha256:141e80f18b99f2effce315f5845d17c27c9544ccaaebc613aff2dfe96910dfe6"},
+    {file = "ftree_kg-0.14.0-py3-none-any.whl", hash = "sha256:b1e2397741ea03a6e9a5cd24555d43dd36a5c517091b64974c593fe7f68d67e5"},
+    {file = "ftree_kg-0.14.0.tar.gz", hash = "sha256:0cffca37f441de76289ff8affc7ae2697bbb6e4b52ba4040f9061193958180ed"},
 ]
 
 [package.dependencies]
 click = ">=8.1.0,<9"
-kgmodule-utils = {version = ">=0.13.2", extras = ["semantic", "sqlite-vec"]}
+kgmodule-utils = {version = ">=0.18.0", extras = ["semantic", "sqlite-vec"]}
 mcp = ">=1.0.0,<2"
 pillow = ">=10.0.0"
 rich = ">=13.0.0,<15.0.0"
@@ -1869,14 +1868,14 @@ referencing = ">=0.31.0"
 
 [[package]]
 name = "kgmodule-utils"
-version = "0.17.0"
+version = "0.18.0"
 description = "Shared types, graph store, semantic index, and pipeline base for the KGModule SDK"
 optional = false
 python-versions = "<3.14,>=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "kgmodule_utils-0.17.0-py3-none-any.whl", hash = "sha256:985c35837669cf63f809d6f823da3790293360240b67363b9705128bf0c57ece"},
-    {file = "kgmodule_utils-0.17.0.tar.gz", hash = "sha256:fb26ecf6e22180aefb2b71802580e0271738d53c75bc5915fe0ec6a182f16fef"},
+    {file = "kgmodule_utils-0.18.0-py3-none-any.whl", hash = "sha256:230adc9bdeb517867c18d9f357d25f619f66a64aee7fef0ee9a7cc125553a818"},
+    {file = "kgmodule_utils-0.18.0.tar.gz", hash = "sha256:b8b02d1f5397e39d1459b8f05af0ae29b218ea183ad21f2a37b533fbe75725c7"},
 ]
 
 [package.dependencies]
@@ -2820,19 +2819,6 @@ files = [
 
 [package.dependencies]
 nvidia-nvjitlink = "*"
-
-[[package]]
-name = "nvidia-cufile"
-version = "1.15.1.6"
-description = "cuFile GPUDirect libraries"
-optional = false
-python-versions = ">=3"
-groups = ["main", "dev"]
-markers = "<empty>"
-files = [
-    {file = "nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44"},
-    {file = "nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1"},
-]
 
 [[package]]
 name = "nvidia-curand"
@@ -6521,4 +6507,4 @@ viz3d = ["PyQt5", "markdown", "param", "pyvista", "pyvistaqt", "trame-vtk"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.14"
-content-hash = "3854fe16dad401f9fa8a4df9d2c755efa8428881794aacdce8a3c2c16c359f60"
+content-hash = "b5b9ed2dd217be4774ff58fa6ee097ebaf6558295e6cc5e90c4ee0c749df096a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,7 @@ diary = [
     "diary-kg>=0.97.0",
 ]
 filetree = [
-    "ftree-kg>=0.13.0",
+    "ftree-kg>=0.14.0",
 ]
 # Multi-format document ingestion: `kgrag ingest`. Converts Word / PowerPoint /
 # Excel / OpenDocument / RTF / EPUB / CSV / PDF to Markdown. Optional because
@@ -224,7 +224,7 @@ pi = [
 all = [
     "diary-kg>=0.97.0",
     "doc-kg>=0.21.2",
-    "ftree-kg>=0.13.0",
+    "ftree-kg>=0.14.0",
     "memory-kg>=0.7.0",
     "pycode-kg>=0.23.1",
     "firecrawl-anydoc>=0.1.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,12 @@ dependencies = [
     # 0.17.0 is the floor now: `kgrag ingest` needs kg_utils.ingest, which
     # shipped to PyPI 2026-08-18. The anydoc import inside it stays guarded
     # regardless, so staging .md/.txt/.rst still needs no extra.
-    "kgmodule-utils>=0.17.0",
+    # 0.18.0 raises it again: QueryScope.time_range reads kg_utils.temporal,
+    # which is a core (stdlib-only) module there, so this needs no new extra.
+    # Sequencing: this floor must not merge before kgmodule-utils 0.18.0 is on
+    # PyPI, or a clean install resolves a kg_utils without `temporal` and
+    # `kg_rag.primitives` fails at import.
+    "kgmodule-utils>=0.18.0",
     # Upper-bounded: mcp 2.0 removed the low-level Server decorator API
     # (`@server.list_tools()` / `@server.call_tool()`) that kg_rag.mcp_server
     # uses. The Server class itself still imports under 2.0, so the failure

--- a/src/kg_rag/adapters/base.py
+++ b/src/kg_rag/adapters/base.py
@@ -10,6 +10,8 @@ from abc import ABC, abstractmethod
 from datetime import UTC, datetime
 from typing import Any
 
+from kg_utils.temporal import TEMPORAL_KEYS
+
 from kg_rag.primitives import CrossHit, CrossSnippet, KGEntry, QueryScope
 from kg_rag.viz import DisplayMode, Viewport
 
@@ -351,3 +353,28 @@ class KGAdapter(ABC):
             "node_count": _to_int(raw.get("node_count")),
             "edge_count": _to_int(raw.get("edge_count")),
         }
+
+
+def node_metadata(node: dict[str, Any]) -> dict[str, Any]:
+    """Extract a node's metadata mapping from a backend query result.
+
+    Backends differ in how they surface it: ``kg_utils.store`` returns a
+    decoded ``metadata`` dict, while some modules flatten the temporal contract
+    keys onto the node itself.  This reads both, preferring the nested mapping
+    and falling back to any contract keys found at the top level, so an adapter
+    populates :attr:`~kg_rag.primitives.CrossHit.metadata` with one call
+    regardless of which shape its backend uses.
+
+    Returning ``{}`` for a node with no metadata is meaningful rather than
+    merely empty: a ``time_range`` scope treats an undated result as out of
+    scope, so a backend that carries no dates drops out of time-scoped queries
+    instead of matching everything.
+
+    :param node: A node dict from a backend query result.
+    :return: The node's metadata mapping, possibly empty.
+    """
+    raw = node.get("metadata")
+    if isinstance(raw, dict) and raw:
+        return dict(raw)
+    flat = {k: node[k] for k in TEMPORAL_KEYS if node.get(k)}
+    return flat

--- a/src/kg_rag/adapters/diary_adapter.py
+++ b/src/kg_rag/adapters/diary_adapter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from kg_rag.adapters.base import KGAdapter
+from kg_rag.adapters.base import KGAdapter, node_metadata
 from kg_rag.primitives import CrossHit, CrossSnippet, KGEntry, KGKind, QueryScope
 
 
@@ -92,6 +92,7 @@ class DiaryKGAdapter(KGAdapter):
                     score=score,
                     summary=h.get("summary", ""),
                     source_path=h.get("source_file", ""),
+                    metadata=node_metadata(h),
                 )
             )
         return hits

--- a/src/kg_rag/adapters/dockg_adapter.py
+++ b/src/kg_rag/adapters/dockg_adapter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from kg_rag.adapters.base import KGAdapter
+from kg_rag.adapters.base import KGAdapter, node_metadata
 from kg_rag.primitives import CrossHit, CrossSnippet, KGEntry, KGKind, QueryScope
 
 
@@ -99,6 +99,7 @@ class DocKGAdapter(KGAdapter):
                     score=round(score, 4),
                     summary=node.get("text") or node.get("title", ""),
                     source_path=node.get("file_path") or "",
+                    metadata=node_metadata(node),
                 )
             )
         return hits

--- a/src/kg_rag/adapters/ftree_adapter.py
+++ b/src/kg_rag/adapters/ftree_adapter.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from kg_rag.adapters.base import KGAdapter
+from kg_rag.adapters.base import KGAdapter, node_metadata
 from kg_rag.primitives import CrossHit, CrossSnippet, KGEntry, KGKind, QueryScope
 
 
@@ -96,6 +96,7 @@ class FTreeKGAdapter(KGAdapter):
                     score=score,
                     summary=n.get("docstring", ""),
                     source_path=n.get("source_path", ""),
+                    metadata=node_metadata(n),
                 )
             )
         return hits

--- a/src/kg_rag/adapters/gutenberg_adapter.py
+++ b/src/kg_rag/adapters/gutenberg_adapter.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from kg_rag.adapters.base import KGAdapter
+from kg_rag.adapters.base import KGAdapter, node_metadata
 from kg_rag.primitives import CrossHit, CrossSnippet, KGEntry, KGKind, QueryScope
 
 
@@ -114,6 +114,7 @@ class GutenbergKGAdapter(KGAdapter):
                     score=round(score, 4),
                     summary=node.get("text") or node.get("title", ""),
                     source_path=node.get("file_path") or "",
+                    metadata=node_metadata(node),
                 )
             )
         return hits

--- a/src/kg_rag/adapters/memory_adapter.py
+++ b/src/kg_rag/adapters/memory_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from kg_rag.adapters.base import KGAdapter
+from kg_rag.adapters.base import KGAdapter, node_metadata
 from kg_rag.primitives import CrossHit, CrossSnippet, KGEntry, KGKind, QueryScope
 
 
@@ -99,6 +99,7 @@ class MemoryKGAdapter(KGAdapter):
                     score=round(score, 4),
                     summary=node.get("text") or node.get("title", ""),
                     source_path=node.get("file_path") or "",
+                    metadata=node_metadata(node),
                 )
             )
         return hits

--- a/src/kg_rag/cli/cmd_timeline.py
+++ b/src/kg_rag/cli/cmd_timeline.py
@@ -1,0 +1,197 @@
+"""
+cmd_timeline.py
+
+Chronological cross-KG query — what happened, in order.
+
+Author: Eric G. Suchanek, PhD
+License: Elastic 2.0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+from kg_utils.temporal import TemporalSpan, read_span
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+from kg_rag.cli.group import cli
+from kg_rag.cli.options import k_option, kind_option, registry_option
+from kg_rag.orchestrator import KGRAG
+from kg_rag.primitives import CrossHit, KGKind, QueryScope
+
+console = Console()
+
+
+def _span_of(hit: CrossHit) -> TemporalSpan | None:
+    """Read a hit's temporal span, or ``None`` when it carries no date."""
+    return read_span(hit.metadata)
+
+
+def _when(span: TemporalSpan, metadata: dict[str, Any] | None = None) -> str:
+    """Render a span for a timeline column.
+
+    Three things this gets right that a naive formatter does not:
+
+    - **Precision is shown, not padded.** A book dated ``1876`` reads as
+      ``1876``, never as a false midnight on the 1st of January.
+    - **Only an explicit end becomes a range.** A year-precision span *implies*
+      an end of 31 December, and printing that implied bound as ``1876 →
+      1876-12-31`` would claim the source said something it did not. The arrow
+      appears only when ``occurred_end`` was actually written.
+    - **A recorded-only date is marked ``~``.** It says when the thing was
+      written down, not when it happened, and a timeline that shows the two
+      identically is lying about one of them.
+
+    :param span: The hit's temporal span.
+    :param metadata: The hit's raw metadata, consulted to tell an explicit
+        ``occurred_end`` from one implied by precision.
+    :return: Short display string.
+    """
+    if span.start is None:
+        return f"~{span.recorded:%Y-%m-%d}" if span.recorded else "—"
+
+    if span.precision == "year":
+        text = f"{span.start:%Y}"
+    elif span.precision == "month":
+        text = f"{span.start:%Y-%m}"
+    else:
+        text = f"{span.start:%Y-%m-%d}"
+
+    explicit_end = (metadata or {}).get("occurred_end")
+    if explicit_end and span.end is not None and span.end.date() != span.start.date():
+        text += f" → {span.end:%Y-%m-%d}"
+    return text
+
+
+@cli.command("timeline")
+@click.argument("query_text")
+@click.option(
+    "--from", "date_from", default=None, help="Earliest date (ISO, e.g. 1876 or 2026-04)."
+)
+@click.option("--to", "date_to", default=None, help="Latest date (ISO). Open-ended if omitted.")
+@k_option
+@kind_option
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON.")
+@click.option(
+    "--min-score",
+    "min_score",
+    default=0.0,
+    show_default=True,
+    help="Drop hits with score below this threshold.",
+)
+@registry_option
+def timeline(query_text, date_from, date_to, k, kind, output_json, min_score, registry):
+    """Chronological cross-KG query — what happened, in order.
+
+    Runs a federated query and orders the results by *when*, not by relevance.
+    A diary entry, a photograph, a conversation topic and a book publication
+    sort into one sequence, because every module writes the same temporal
+    contract.
+
+    \b
+    QUERY_TEXT  Natural-language query string
+
+    Dates accept any ISO precision, and the precision is meaningful: --from 1876
+    means the whole of 1876, not its first midnight.
+
+    \b
+    Examples:
+        kgrag timeline "fire"
+        kgrag timeline "the office" --from 1666-09 --to 1666-10
+        kgrag timeline "manifold work" --from 2026-04
+        kgrag timeline "photographs" --from 1998 --kind filetree
+
+    Hits that carry no date at all are counted and reported, never silently
+    dropped — a module that has not adopted the temporal contract would
+    otherwise look like a module with nothing to say.
+    """
+    scope = QueryScope(time_range=(date_from, date_to)) if (date_from or date_to) else None
+
+    with KGRAG(registry_path=registry) as kg:
+        result = kg.query(
+            query_text,
+            k=k,
+            kinds=[KGKind.from_str(kind)] if kind else None,
+            min_score=min_score,
+            scope=scope,
+        )
+
+    if result.kgs_queried == 0:
+        console.print("[yellow]No available KGs to query. Register and build some first.[/yellow]")
+        return
+
+    dated: list[tuple[TemporalSpan, CrossHit]] = []
+    undated: list[CrossHit] = []
+    for hit in result.hits:
+        span = _span_of(hit)
+        if span is None:
+            undated.append(hit)
+        else:
+            dated.append((span, hit))
+
+    dated.sort(key=lambda pair: pair[0].sort_key)
+
+    if output_json:
+        import json  # pylint: disable=import-outside-toplevel
+
+        payload: dict[str, Any] = {
+            "query": query_text,
+            "time_range": [date_from, date_to],
+            "dated": [
+                {
+                    "when": _when(span, hit.metadata),
+                    "occurred_start": hit.metadata.get("occurred_start"),
+                    "occurred_end": hit.metadata.get("occurred_end"),
+                    "recorded_at": hit.metadata.get("recorded_at"),
+                    "kg": hit.kg_name,
+                    "kind": hit.kg_kind.value,
+                    "node_id": hit.node_id,
+                    "name": hit.name,
+                    "score": round(hit.score, 4),
+                    "summary": hit.summary,
+                    "source_path": hit.source_path,
+                }
+                for span, hit in dated
+            ],
+            "undated_count": len(undated),
+        }
+        console.print_json(json.dumps(payload))
+        return
+
+    window = ""
+    if date_from or date_to:
+        window = f"  [{date_from or '…'} → {date_to or '…'}]"
+    table = Table(
+        title=f"Timeline: {query_text!r}{window}  "
+        f"[{len(dated)} dated across {result.kgs_queried} KG(s)]",
+        box=box.ROUNDED,
+        show_lines=False,
+    )
+    table.add_column("When", style="green", width=24)
+    table.add_column("KG", style="bold")
+    table.add_column("Kind", style="magenta", width=8)
+    table.add_column("Name")
+    table.add_column("Summary")
+
+    for span, hit in dated:
+        table.add_row(
+            _when(span, hit.metadata),
+            hit.kg_name,
+            hit.kg_kind.value,
+            hit.name,
+            (hit.summary[:60] + "…") if len(hit.summary) > 60 else hit.summary,
+        )
+
+    if not dated:
+        console.print("[yellow]No dated results.[/yellow]")
+    else:
+        console.print(table)
+
+    if undated:
+        console.print(
+            f"[dim]{len(undated)} undated hit(s) not shown — "
+            f"their module does not write the temporal contract.[/dim]"
+        )

--- a/src/kg_rag/cli/main.py
+++ b/src/kg_rag/cli/main.py
@@ -24,6 +24,7 @@ import kg_rag.cli.cmd_models  # noqa: F401
 import kg_rag.cli.cmd_query  # noqa: F401
 import kg_rag.cli.cmd_registry  # noqa: F401
 import kg_rag.cli.cmd_synthesize  # noqa: F401
+import kg_rag.cli.cmd_timeline  # noqa: F401
 import kg_rag.cli.cmd_viz  # noqa: F401
 import kg_rag.cli.cmd_viz2d  # noqa: F401
 from kg_rag.cli.group import cli  # noqa: F401 — re-exported as entrypoint

--- a/src/kg_rag/orchestrator.py
+++ b/src/kg_rag/orchestrator.py
@@ -255,7 +255,11 @@ class KGRAG:
                 hits = self._query_adapter(adapter, q, k, min_score, semantic_floor, scope)
                 if scope:
                     hits = [
-                        h for h in hits if scope.matches(source_path=h.source_path, kind=h.kind)
+                        h
+                        for h in hits
+                        if scope.matches(
+                            source_path=h.source_path, kind=h.kind, metadata=h.metadata
+                        )
                     ]
                 all_hits.extend(hits)
                 by_kg[entry.name] = hits
@@ -311,7 +315,11 @@ class KGRAG:
             try:
                 snippets = self._pack_adapter(adapter, q, k, context, semantic_floor, scope)
                 if scope:
-                    snippets = [s for s in snippets if scope.matches(source_path=s.source_path)]
+                    snippets = [
+                        s
+                        for s in snippets
+                        if scope.matches(source_path=s.source_path, metadata=s.metadata)
+                    ]
                 all_snippets.extend(snippets)
                 kgs_queried += 1
             except Exception:  # pylint: disable=broad-exception-caught

--- a/src/kg_rag/primitives.py
+++ b/src/kg_rag/primitives.py
@@ -13,6 +13,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from kg_utils.temporal import read_span
+
 
 class KGKind(StrEnum):
     """Kind of knowledge graph."""
@@ -214,12 +216,27 @@ class QueryScope:
         (e.g. ``("chunk", "section")`` to drop structural/topic nodes).  Note
         that snippet packs may not carry a ``kind``; kind filtering on snippets
         is therefore only reliable via adapter pushdown.
+    :param time_range: Keep only results whose occurrence overlaps this
+        ``(start, end)`` window, as ISO-8601 strings.  Either bound may be
+        ``None`` for an open-ended window, so ``("2026-04-01", None)`` means
+        "April 2026 onwards".  Read against the shared temporal contract in
+        :mod:`kg_utils.temporal`, so precision is honoured: a node dated
+        ``"1876"`` overlaps any window touching that year.
+
+        Unlike ``node_kinds``, a result carrying **no** temporal metadata is
+        rejected when this constraint is set.  Undated results cannot answer
+        "when", and admitting them would make a time window meaningless — a
+        code KG would return every function for any window.  The practical
+        consequence: a module that has not yet adopted the temporal contract
+        drops out of time-scoped queries entirely, which is the honest
+        outcome, not a bug.
     :param metadata_eq: Reserved for future metadata-equality scoping.  Accepted
         for API stability but not yet enforced.
     """
 
     source_path_prefixes: tuple[str, ...] | None = None
     node_kinds: tuple[str, ...] | None = None
+    time_range: tuple[str | None, str | None] | None = None
     metadata_eq: dict[str, str] | None = None
 
     def __post_init__(self) -> None:
@@ -228,25 +245,42 @@ class QueryScope:
             object.__setattr__(self, "source_path_prefixes", tuple(self.source_path_prefixes))
         if self.node_kinds is not None:
             object.__setattr__(self, "node_kinds", tuple(self.node_kinds))
+        if self.time_range is not None:
+            start, end = self.time_range
+            object.__setattr__(self, "time_range", (start or None, end or None))
 
     @property
     def is_empty(self) -> bool:
         """True if this scope imposes no constraints (a no-op filter)."""
-        return not (self.source_path_prefixes or self.node_kinds or self.metadata_eq)
+        return not (
+            self.source_path_prefixes
+            or self.node_kinds
+            or self.metadata_eq
+            or (self.time_range and any(self.time_range))
+        )
 
     def __bool__(self) -> bool:
         return not self.is_empty
 
-    def matches(self, *, source_path: str = "", kind: str | None = None) -> bool:
+    def matches(
+        self,
+        *,
+        source_path: str = "",
+        kind: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
         """Return True if a result with these attributes is in scope.
 
         Applied as a post-filter for adapters without pushdown.  A ``None``
         ``kind`` is treated as "unknown" and is **not** rejected by a
         ``node_kinds`` constraint, so kind filtering never silently drops
-        snippets that simply lack a kind field.
+        snippets that simply lack a kind field.  ``time_range`` deliberately
+        takes the opposite stance on missing data — see the class docstring.
 
         :param source_path: The result's source/document path.
         :param kind: The result's node kind, or None if unknown.
+        :param metadata: The result's node metadata, carrying the temporal
+            contract keys if the producing module writes them.
         :return: True if the result satisfies all enforced constraints.
         """
         if self.source_path_prefixes:
@@ -255,6 +289,13 @@ class QueryScope:
                 return False
         if self.node_kinds and kind is not None and kind not in self.node_kinds:
             return False
+        if self.time_range and any(self.time_range):
+            span = read_span(metadata)
+            if span is None:
+                return False
+            start, end = self.time_range
+            if not span.overlaps(start, end):
+                return False
         return True
 
 
@@ -270,6 +311,10 @@ class CrossHit:
     :param score: Relevance score (higher is better).
     :param summary: Short description or docstring snippet.
     :param source_path: File/document path within the repo.
+    :param metadata: Node metadata carried through from the source KG.  Adapters
+        populate it with at least the :mod:`kg_utils.temporal` contract keys
+        where their nodes have them; without it a ``time_range`` scope has
+        nothing to read and the hit is treated as undated.
     """
 
     kg_name: str
@@ -280,6 +325,7 @@ class CrossHit:
     score: float
     summary: str = ""
     source_path: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -312,6 +358,10 @@ class CrossSnippet:
     :param end_lineno: Ending line number (code KGs).
     :param content: The raw source text.
     :param score: Relevance score.
+    :param metadata: Node metadata carried through from the source KG, including
+        the :mod:`kg_utils.temporal` contract keys where the producing module
+        writes them.  A ``time_range`` scope reads this; a snippet without it
+        counts as undated and is filtered out.
     """
 
     kg_name: str
@@ -322,6 +372,7 @@ class CrossSnippet:
     score: float = 0.0
     lineno: int | None = None
     end_lineno: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -948,3 +948,58 @@ class TestIABookKGAdapterStub:
         adapter = IABookKGAdapter(entry)
         report = adapter.analyze()
         assert "unavailable" in report.lower()
+
+
+# ---------------------------------------------------------------------------
+# node_metadata — the bridge that makes time scoping reach real hits
+# ---------------------------------------------------------------------------
+
+
+class TestNodeMetadataHelper:
+    """Adapters must carry node metadata into hits or time scoping cannot work.
+
+    QueryScope.time_range reads CrossHit.metadata; if an adapter leaves it
+    empty, every hit from that KG counts as undated and is filtered out. This
+    helper is what each adapter calls to populate it.
+    """
+
+    def test_reads_nested_metadata(self):
+        from kg_rag.adapters.base import node_metadata
+
+        node = {"id": "n", "metadata": {"occurred_start": "2026-04-15"}}
+        assert node_metadata(node) == {"occurred_start": "2026-04-15"}
+
+    def test_reads_flattened_contract_keys(self):
+        """Some modules put the contract keys straight on the node."""
+        from kg_rag.adapters.base import node_metadata
+
+        node = {"id": "n", "occurred_start": "2026-04-15", "recorded_at": "2026-08-17"}
+        assert node_metadata(node) == {
+            "occurred_start": "2026-04-15",
+            "recorded_at": "2026-08-17",
+        }
+
+    def test_nested_wins_over_flattened(self):
+        from kg_rag.adapters.base import node_metadata
+
+        node = {"metadata": {"occurred_start": "2026-04-15"}, "occurred_start": "1999-01-01"}
+        assert node_metadata(node)["occurred_start"] == "2026-04-15"
+
+    def test_undated_node_yields_empty(self):
+        from kg_rag.adapters.base import node_metadata
+
+        assert node_metadata({"id": "n", "kind": "function"}) == {}
+
+    def test_ignores_non_dict_metadata(self):
+        from kg_rag.adapters.base import node_metadata
+
+        assert node_metadata({"metadata": "not-a-dict"}) == {}
+
+    def test_returns_a_copy(self):
+        """Mutating a hit's metadata must not reach back into the backend's node."""
+        from kg_rag.adapters.base import node_metadata
+
+        original = {"occurred_start": "2026-04-15"}
+        out = node_metadata({"metadata": original})
+        out["occurred_start"] = "changed"
+        assert original["occurred_start"] == "2026-04-15"

--- a/tests/test_cmd_timeline.py
+++ b/tests/test_cmd_timeline.py
@@ -1,0 +1,158 @@
+"""Unit tests for `kgrag timeline`.
+
+The command is the point at which the temporal contract becomes something a
+person can ask a question with: a diary entry, a book, a photograph and a
+conversation topic sorted into one sequence, because every module writes the
+same three keys.
+
+What is worth pinning is not that it runs, but that it does not *lie* — about
+precision, about implied bounds, or about what it left out.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+from kg_utils.temporal import read_span
+
+from kg_rag.cli.cmd_timeline import _span_of, _when
+from kg_rag.cli.main import cli
+from kg_rag.primitives import CrossHit, KGKind, QueryScope
+
+
+def _hit(name: str, metadata: dict, kg: str = "kg", score: float = 0.5) -> CrossHit:
+    return CrossHit(
+        kg_name=kg,
+        kg_kind=KGKind.DOC,
+        node_id=f"n:{name}",
+        name=name,
+        kind="chunk",
+        score=score,
+        summary=f"{name} summary",
+        source_path="p",
+        metadata=metadata,
+    )
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestWhenRendering:
+    """The column must show the precision the source actually had."""
+
+    def test_year_stays_a_year(self):
+        m = {"occurred_start": "1876"}
+        assert _when(read_span(m), m) == "1876"
+
+    def test_year_does_not_show_its_implied_end(self):
+        """`1876 → 1876-12-31` would claim a bound the source never wrote."""
+        m = {"occurred_start": "1876"}
+        assert "→" not in _when(read_span(m), m)
+
+    def test_month_stays_a_month(self):
+        m = {"occurred_start": "2026-04"}
+        assert _when(read_span(m), m) == "2026-04"
+
+    def test_day_renders_as_a_day(self):
+        m = {"occurred_start": "1666-09-02"}
+        assert _when(read_span(m), m) == "1666-09-02"
+
+    def test_an_explicit_interval_shows_its_range(self):
+        m = {"occurred_start": "2026-04-01", "occurred_end": "2026-04-15"}
+        assert _when(read_span(m), m) == "2026-04-01 → 2026-04-15"
+
+    def test_recorded_only_is_marked(self):
+        """A written-down date is a weaker claim and must look different."""
+        m = {"recorded_at": "2025-06-15"}
+        assert _when(read_span(m), m).startswith("~")
+
+    def test_nothing_renders_as_a_dash(self):
+        span = read_span({"recorded_at": "2025-06-15"})
+        object.__setattr__(span, "recorded", None) if hasattr(span, "recorded") else None
+        # A span with neither start nor recorded is degenerate; guard the branch.
+        assert _when(span, {}) in {"—", "~2025-06-15"}
+
+
+class TestOrdering:
+    """Sorted by when, not by relevance — that is what makes it a timeline."""
+
+    def _sorted_names(self, hits):
+        dated = [(_span_of(h), h) for h in hits if _span_of(h) is not None]
+        dated.sort(key=lambda pair: pair[0].sort_key)
+        return [h.name for _, h in dated]
+
+    def test_chronological_not_by_score(self):
+        hits = [
+            _hit("book", {"occurred_start": "1876"}, score=0.1),
+            _hit("diary", {"occurred_start": "1666-09-02"}, score=0.9),
+            _hit("topic", {"occurred_start": "2026-04-01"}, score=0.5),
+        ]
+        assert self._sorted_names(hits) == ["diary", "book", "topic"]
+
+    def test_modules_interleave(self):
+        """Four module shapes, one sequence."""
+        hits = [
+            _hit("topic", {"occurred_start": "2026-04-01", "occurred_end": "2026-04-15"}),
+            _hit("photo", {"occurred_start": "1998-07-04", "recorded_at": "2024-04-01"}),
+            _hit("diary", {"occurred_start": "1666-09-02"}),
+            _hit("note", {"recorded_at": "2025-06-15"}),
+        ]
+        assert self._sorted_names(hits) == ["diary", "photo", "note", "topic"]
+
+    def test_a_photo_sorts_by_capture_not_by_copy(self):
+        hits = [
+            _hit("photo", {"occurred_start": "1998-07-04", "recorded_at": "2024-04-01"}),
+            _hit("later", {"occurred_start": "2000-01-01"}),
+        ]
+        assert self._sorted_names(hits)[0] == "photo"
+
+
+class TestUndatedAreCounted:
+    def test_a_hit_with_no_metadata_has_no_span(self):
+        assert _span_of(_hit("x", {})) is None
+
+    def test_undated_are_separable_from_dated(self):
+        hits = [_hit("dated", {"occurred_start": "1876"}), _hit("undated", {})]
+        dated = [h for h in hits if _span_of(h) is not None]
+        undated = [h for h in hits if _span_of(h) is None]
+        assert [h.name for h in dated] == ["dated"]
+        assert [h.name for h in undated] == ["undated"]
+
+
+class TestWindowing:
+    """The scope filter the command builds from --from/--to."""
+
+    def _matches(self, metadata, start, end):
+        scope = QueryScope(time_range=(start, end))
+        return scope.matches(source_path="p", kind="chunk", metadata=metadata)
+
+    def test_a_year_window_selects_a_year_dated_book(self):
+        assert self._matches({"occurred_start": "1876"}, "1876-06-01", "1876-06-30")
+
+    def test_a_window_inside_an_interval_matches(self):
+        m = {"occurred_start": "2026-04-01", "occurred_end": "2026-04-15"}
+        assert self._matches(m, "2026-04-05", "2026-04-06")
+
+    def test_outside_the_window_is_rejected(self):
+        assert not self._matches({"occurred_start": "1876"}, "1900-01-01", "1901-01-01")
+
+    def test_undated_is_rejected_by_a_window(self):
+        """Deliberate: an undated node cannot be shown to be in range."""
+        assert not self._matches({}, "1876-01-01", "1876-12-31")
+
+    def test_recorded_only_is_still_windowable(self):
+        assert self._matches({"recorded_at": "2025-06-15"}, "2025-06-01", "2025-06-30")
+
+
+class TestCommandSurface:
+    def test_timeline_is_registered(self, runner):
+        result = runner.invoke(cli, ["--help"])
+        assert "timeline" in result.output
+
+    def test_help_documents_the_date_options(self, runner):
+        result = runner.invoke(cli, ["timeline", "--help"])
+        assert result.exit_code == 0
+        assert "--from" in result.output
+        assert "--to" in result.output

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -524,3 +524,113 @@ class TestQueryScope:
         pack = kgrag.pack("desert", k=5, scope=scope)
         assert [s.source_path for s in pack.snippets] == ["science-fiction/Dune.md"]
         kgrag.close()
+
+
+# ---------------------------------------------------------------------------
+# time_range post-filter (the degradation path for adapters without pushdown)
+# ---------------------------------------------------------------------------
+
+
+def _dated_hit(kg_name: str, source_path: str, occurred: str | None, score: float = 0.9):
+    """A hit carrying (or deliberately lacking) the temporal contract keys."""
+    return CrossHit(
+        kg_name=kg_name,
+        kg_kind=KGKind.DIARY,
+        node_id=f"{kg_name}:{source_path}",
+        name=source_path,
+        kind="entry",
+        score=score,
+        source_path=source_path,
+        metadata={"occurred_start": occurred} if occurred else {},
+    )
+
+
+class TestTimeRangeScope:
+    """Time scoping must actually filter on the post-filter path.
+
+    Before CrossHit carried metadata there was nothing here to read, so a
+    time-scoped query against an adapter without pushdown would have returned
+    everything while appearing to be scoped — the silent-no-op this wiring
+    exists to prevent.
+    """
+
+    def _registered(self, tmp_path, adapter):
+        kgrag = KGRAG(registry_path=tmp_path / "reg.sqlite")
+        entry = _make_entry(tmp_path, "journal", KGKind.DIARY)
+        kgrag.registry.register(entry)
+        kgrag._adapters[entry.name] = adapter
+        return kgrag
+
+    def test_filters_out_of_window_hits(self, tmp_path):
+        from kg_rag.primitives import QueryScope
+
+        adapter = _mock_adapter(
+            hits=[
+                _dated_hit("journal", "april.md", "2026-04-15"),
+                _dated_hit("journal", "august.md", "2026-08-17"),
+            ]
+        )
+        adapter.supports_scope = False
+        kgrag = self._registered(tmp_path, adapter)
+
+        result = kgrag.query(
+            "what happened", k=5, scope=QueryScope(time_range=("2026-04-01", "2026-04-30"))
+        )
+        paths = [h.source_path for h in result.hits]
+        assert paths == ["april.md"]
+        kgrag.close()
+
+    def test_undated_hits_are_dropped(self, tmp_path):
+        """A module that has not adopted the contract drops out of time queries."""
+        from kg_rag.primitives import QueryScope
+
+        adapter = _mock_adapter(
+            hits=[
+                _dated_hit("journal", "dated.md", "2026-04-15"),
+                _dated_hit("journal", "undated.md", None),
+            ]
+        )
+        adapter.supports_scope = False
+        kgrag = self._registered(tmp_path, adapter)
+
+        result = kgrag.query("x", k=5, scope=QueryScope(time_range=("2026-04-01", "2026-04-30")))
+        assert [h.source_path for h in result.hits] == ["dated.md"]
+        kgrag.close()
+
+    def test_no_time_scope_keeps_undated_hits(self, tmp_path):
+        """Undated hits are only excluded when a time window is actually set."""
+        adapter = _mock_adapter(hits=[_dated_hit("journal", "undated.md", None)])
+        adapter.supports_scope = False
+        kgrag = self._registered(tmp_path, adapter)
+
+        result = kgrag.query("x", k=5)
+        assert len(result.hits) == 1
+        kgrag.close()
+
+    def test_open_ended_window(self, tmp_path):
+        from kg_rag.primitives import QueryScope
+
+        adapter = _mock_adapter(
+            hits=[
+                _dated_hit("journal", "old.md", "2025-01-01"),
+                _dated_hit("journal", "new.md", "2026-08-17"),
+            ]
+        )
+        adapter.supports_scope = False
+        kgrag = self._registered(tmp_path, adapter)
+
+        result = kgrag.query("x", k=5, scope=QueryScope(time_range=("2026-01-01", None)))
+        assert [h.source_path for h in result.hits] == ["new.md"]
+        kgrag.close()
+
+    def test_time_scope_is_pushed_down_when_supported(self, tmp_path):
+        from kg_rag.primitives import QueryScope
+
+        adapter = _mock_adapter(hits=[_dated_hit("journal", "april.md", "2026-04-15")])
+        adapter.supports_scope = True
+        kgrag = self._registered(tmp_path, adapter)
+        scope = QueryScope(time_range=("2026-04-01", "2026-04-30"))
+
+        kgrag.query("x", k=5, scope=scope)
+        assert adapter.query.call_args.kwargs.get("scope") == scope
+        kgrag.close()

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -462,3 +462,103 @@ class TestQueryScope:
     def test_empty_scope_matches_everything(self):
         scope = QueryScope()
         assert scope.matches(source_path="anything", kind="whatever") is True
+
+
+# ---------------------------------------------------------------------------
+# QueryScope.time_range — time as a scoping axis
+# ---------------------------------------------------------------------------
+
+
+class TestQueryScopeTimeRange:
+    """Time scoping reads the shared kg_utils.temporal contract.
+
+    The asymmetry worth remembering: an unknown ``kind`` is admitted, an
+    unknown *date* is rejected. Admitting undated results would make a time
+    window meaningless — every function in a code KG would match every window.
+    """
+
+    _DATED = {"occurred_start": "2026-04-15"}
+
+    def test_hit_inside_window_matches(self):
+        scope = QueryScope(time_range=("2026-04-01", "2026-04-30"))
+        assert scope.matches(metadata=self._DATED) is True
+
+    def test_hit_outside_window_rejected(self):
+        scope = QueryScope(time_range=("2026-05-01", "2026-05-31"))
+        assert scope.matches(metadata=self._DATED) is False
+
+    def test_undated_result_is_rejected(self):
+        scope = QueryScope(time_range=("2026-04-01", "2026-04-30"))
+        assert scope.matches(metadata={}) is False
+        assert scope.matches(metadata=None) is False
+        assert scope.matches(metadata={"kind": "function"}) is False
+
+    def test_unknown_kind_still_admitted(self):
+        """The opposite stance from time, and both are deliberate."""
+        scope = QueryScope(node_kinds=("chunk",))
+        assert scope.matches(kind=None) is True
+
+    def test_open_ended_windows(self):
+        assert QueryScope(time_range=("2026-01-01", None)).matches(metadata=self._DATED)
+        assert QueryScope(time_range=(None, "2026-12-31")).matches(metadata=self._DATED)
+        assert not QueryScope(time_range=("2027-01-01", None)).matches(metadata=self._DATED)
+
+    def test_precision_is_honoured(self):
+        """A year-dated node overlaps any window touching that year."""
+        scope = QueryScope(time_range=("1876-03-04", "1876-03-04"))
+        assert scope.matches(metadata={"occurred_start": "1876"}) is True
+        assert scope.matches(metadata={"occurred_start": "1877"}) is False
+
+    def test_occurred_beats_recorded(self):
+        """An entry written later about an earlier day belongs to the earlier day."""
+        metadata = {"occurred_start": "2026-04-15", "recorded_at": "2026-08-17"}
+        assert QueryScope(time_range=("2026-04-01", "2026-04-30")).matches(metadata=metadata)
+
+    def test_recorded_only_falls_back(self):
+        metadata = {"recorded_at": "2026-04-15"}
+        assert QueryScope(time_range=("2026-04-01", "2026-04-30")).matches(metadata=metadata)
+
+    def test_time_range_combines_with_other_constraints(self):
+        scope = QueryScope(source_path_prefixes=("journal/",), time_range=("2026-04-01", None))
+        assert scope.matches(source_path="journal/x.md", metadata=self._DATED) is True
+        assert scope.matches(source_path="other/x.md", metadata=self._DATED) is False
+
+    def test_empty_bounds_are_not_a_constraint(self):
+        assert QueryScope(time_range=(None, None)).is_empty is True
+        assert QueryScope(time_range=("", "")).is_empty is True
+        assert QueryScope(time_range=(None, None)).matches(metadata={}) is True
+
+    def test_time_range_makes_scope_non_empty(self):
+        scope = QueryScope(time_range=("2026-04-01", None))
+        assert scope.is_empty is False
+        assert bool(scope) is True
+
+    def test_scope_stays_hashable(self):
+        """Scopes are frozen and get used as dict keys / cache keys."""
+        assert hash(QueryScope(time_range=("2026-01-01", None))) is not None
+
+
+class TestHitMetadataPassthrough:
+    def test_crosshit_metadata_defaults_empty(self):
+        hit = CrossHit(
+            kg_name="k", kg_kind=KGKind.DOC, node_id="n", name="n", kind="chunk", score=1.0
+        )
+        assert hit.metadata == {}
+
+    def test_crosshit_carries_metadata(self):
+        hit = CrossHit(
+            kg_name="k",
+            kg_kind=KGKind.DOC,
+            node_id="n",
+            name="n",
+            kind="chunk",
+            score=1.0,
+            metadata={"occurred_start": "2026-04-15"},
+        )
+        assert hit.metadata["occurred_start"] == "2026-04-15"
+
+    def test_crosssnippet_metadata_defaults_empty(self):
+        snip = CrossSnippet(
+            kg_name="k", kg_kind=KGKind.DOC, node_id="n", source_path="p", content="c"
+        )
+        assert snip.metadata == {}


### PR DESCRIPTION
## What

Time becomes a federation axis. Three pieces, in order:

1. **`QueryScope.time_range`** -- a new scope field adapters can honor (or
   ignore, per the existing `supports_scope` opt-out) to filter cross-KG
   queries to a date window.
2. **Metadata on hits** -- `CrossHit`/`CrossSnippet` now carry the adapter's
   `metadata` dict through to the caller, so a hit can surface the
   `kg_utils.temporal` contract fields (`occurred_at`, `precision`, etc.)
   instead of dropping them at the orchestrator boundary.
3. **`kgrag timeline`** -- a CLI command that queries across every registered
   KG and renders results in chronological order, using (1) and (2).

Plus a same-day follow-up: floors and relocks `ftree-kg` at `0.14.0`, now
published -- it carries the temporal-contract adoption and the
metadata-surfacing fixes this branch's own `filetree` adapter path depends on.

## Why

This is the layer a dedicated "TimelineKG" module would have needed anyway.
Building the federation axis first, and adding `kgrag timeline` as a thin
consumer of it, answers the "chronological cross-KG query" question without
a new module. Whether a standalone TimelineKG is still worth building is an
open question, tracked in `kgrag_priv/docs/TIMELINE_KG_PROPOSAL.md` -- on the
evidence so far it looks unnecessary.

## Status

Depends on the shared `kg_utils.temporal` contract shipped in
`kgmodule-utils 0.18.0` (published) and the `ftree_kg` temporal/metadata work
in `ftree-kg 0.14.0` (published). Both are now on PyPI and this branch's lock
reflects them.

Sibling PRs adopting the same contract: `doc_kg` #29, `diary_kg` #19.
`agent_kg`, `gutenberg_kg` carry the same branch pushed without a PR (no
review needed there -- pure adoption, no shared surface).

## Testing

574 passed. `ruff`, `ty`, and `pre-commit --all-files` (scoped to staged
files) clean.
