### PR TITLE
Fix ftree_adapter.py: pack() dropped snippet metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   imports it and reports unavailable until it is.
 
   Its `query()`/`pack()` reshaping reads `node["relevance"]["score"]` and
-  `node["snippet"]`, which is where `kg_utils.pipeline.KGModule` actually
-  puts them -- not the top-level `score` / `node_id` keys and `.snippets`
-  list that `ftree_adapter.py` still assumes. Verified live against a real
-  KGModule.query()/pack() call: `ftree_adapter.py`'s `node_id` is always
-  `""`, its score-based filtering is always a no-op, and its `pack()`
-  always returns `[]`. Not fixed here -- flagged for a dedicated pass; see
-  kgrag_priv's fleet sweep plan.
+  `node["snippet"]`, which is where the generic `kg_utils.pipeline.KGModule`
+  base class puts them. That prompted a check of `ftree_adapter.py`, which
+  reads the older `node_id` / top-level `score` / `.snippets` shape instead
+  -- initially logged here as a bug on the assumption every KGModule
+  subclass returns the shared base shape. It does not: `FileTreeKG`
+  overrides `query()`/`pack()` itself and deliberately keeps the older
+  shape for backward compatibility (`ftree_kg/module.py`'s own docstrings
+  say so, and a live build confirmed `node_id`/`score` were already
+  correct). Retracted below.
+
+### Fixed
+
+- **`ftree_adapter.py.pack()` dropped snippet metadata.** `FileTreeKG.pack()`
+  populates each snippet's `metadata` (including the temporal contract
+  keys); `query()`'s `CrossHit` already read it via `node_metadata()`, but
+  `pack()`'s `CrossSnippet` never did, so a `time_range`-scoped `pack()`
+  call saw every FTreeKG snippet as undated even though the same KG's
+  `query()` correctly dated it. One line (`metadata=node_metadata(s)`),
+  pinned by two new tests in `tests/test_adapters.py`. This is the one real
+  defect in `ftree_adapter.py`; the `node_id`/score/`.snippets` reads noted
+  above are correct as written.
 
 ## [0.14.0] - 2026-08-22
 

--- a/src/kg_rag/adapters/ftree_adapter.py
+++ b/src/kg_rag/adapters/ftree_adapter.py
@@ -132,6 +132,12 @@ class FTreeKGAdapter(KGAdapter):
                 source_path=s.get("source_path", ""),
                 content=s.get("content", ""),
                 score=s.get("score", 0.0),
+                # FileTreeKG.pack() populates each snippet's "metadata" (the
+                # temporal contract keys included) -- query() already reads it
+                # via node_metadata() below; pack() was dropping it, so a
+                # time_range-scoped pack() call saw every FTreeKG snippet as
+                # undated even though the same KG's query() correctly dated it.
+                metadata=node_metadata(s),
             )
             for s in snippets
         ]

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -31,6 +31,7 @@ import pytest
 
 from kg_rag.adapters import make_adapter
 from kg_rag.adapters.dockg_adapter import DocKGAdapter
+from kg_rag.adapters.ftree_adapter import FTreeKGAdapter
 from kg_rag.adapters.genealogy_adapter import GenealogyKGAdapter
 from kg_rag.adapters.gutenberg_adapter import GutenbergKGAdapter
 from kg_rag.adapters.ia_adapter import IABookKGAdapter
@@ -88,6 +89,11 @@ class TestMakeAdapter:
         entry = _entry(tmp_path, KGKind.GENEALOGY)
         adapter = make_adapter(entry)
         assert isinstance(adapter, GenealogyKGAdapter)
+
+    def test_filetree_kind_returns_ftreekg_adapter(self, tmp_path):
+        entry = _entry(tmp_path, KGKind.FILETREE)
+        adapter = make_adapter(entry)
+        assert isinstance(adapter, FTreeKGAdapter)
 
     def test_entry_is_stored(self, tmp_path):
         entry = _entry(tmp_path, KGKind.CODE)
@@ -1242,3 +1248,85 @@ class TestGenealogyKGAdapterSnapshotMetrics:
             "person_count": 12,
             "family_count": 4,
         }
+
+
+# ---------------------------------------------------------------------------
+# FTreeKGAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestFTreeKGAdapterFieldMapping:
+    """FileTreeKG.query()/pack() do NOT return the generic
+    kg_utils.pipeline.KGModule shape -- FileTreeKG overrides both methods
+    itself and deliberately keeps the older "node_id" / top-level "score" /
+    populated SnippetPack.snippets shape for backward compatibility (see
+    ftree_kg/module.py's own docstrings). Verified live against a real
+    FileTreeKG build, not assumed: node_id and score were already correct
+    here. What pack() was NOT doing was forwarding the metadata dict that
+    FileTreeKG.pack() puts on every snippet (query()'s CrossHit already got
+    it via node_metadata()) -- a time_range-scoped pack() call therefore saw
+    every FTreeKG snippet as undated. These tests pin the fix.
+    """
+
+    def test_query_passes_through_node_id_score_and_metadata(self, tmp_path):
+        entry = _entry(tmp_path, KGKind.FILETREE, with_sqlite=True)
+        mock_kg = MagicMock()
+        mock_kg.query.return_value.nodes = [
+            {
+                "id": "file:readme.txt:readme.txt",
+                "node_id": "file:readme.txt:readme.txt",
+                "name": "readme.txt",
+                "kind": "file",
+                "docstring": "a readme",
+                "source_path": "readme.txt",
+                "score": 0.87,
+                "metadata": {"occurred_start": "2026-01-01T00:00:00+00:00"},
+            }
+        ]
+
+        adapter = FTreeKGAdapter(entry)
+        adapter._kg = mock_kg
+
+        hits = adapter.query("readme")
+        assert len(hits) == 1
+        assert hits[0].node_id == "file:readme.txt:readme.txt"
+        assert hits[0].score == 0.87
+        assert hits[0].metadata == {"occurred_start": "2026-01-01T00:00:00+00:00"}
+
+    def test_pack_carries_metadata_from_the_snippet_dict(self, tmp_path):
+        entry = _entry(tmp_path, KGKind.FILETREE, with_sqlite=True)
+        mock_kg = MagicMock()
+        mock_kg.pack.return_value.snippets = [
+            {
+                "node_id": "file:readme.txt:readme.txt",
+                "source_path": "readme.txt",
+                "content": "file: readme.txt\na readme",
+                "score": 0.87,
+                "kind": "file",
+                "name": "readme.txt",
+                "metadata": {"occurred_start": "2026-01-01T00:00:00+00:00"},
+            }
+        ]
+
+        adapter = FTreeKGAdapter(entry)
+        adapter._kg = mock_kg
+
+        snippets = adapter.pack("readme")
+        assert len(snippets) == 1
+        assert snippets[0].node_id == "file:readme.txt:readme.txt"
+        # This is the regression the fix pins: before it, metadata was
+        # dropped here even though FileTreeKG.pack() populates it.
+        assert snippets[0].metadata == {"occurred_start": "2026-01-01T00:00:00+00:00"}
+
+    def test_pack_omits_metadata_key_gracefully(self, tmp_path):
+        entry = _entry(tmp_path, KGKind.FILETREE, with_sqlite=True)
+        mock_kg = MagicMock()
+        mock_kg.pack.return_value.snippets = [
+            {"node_id": "n", "source_path": "p", "content": "c", "score": 0.5}
+        ]
+
+        adapter = FTreeKGAdapter(entry)
+        adapter._kg = mock_kg
+
+        snippets = adapter.pack("x")
+        assert snippets[0].metadata == {}


### PR DESCRIPTION
## Summary

- Fixes a real, verified defect: `FTreeKGAdapter.pack()` built `CrossSnippet`
  without `metadata=`, even though `FileTreeKG.pack()` populates it on every
  snippet and `query()`'s `CrossHit` already read it. A `time_range`-scoped
  `pack()` call therefore saw every FTreeKG snippet as undated.
- Retracts a wrong claim from the prior commit's changelog entry, which
  assumed every `kg_utils.pipeline.KGModule` subclass returns the shared base
  shape (`node["id"]`, `node["relevance"]["score"]`, `node["snippet"]`).
  `FileTreeKG` overrides `query()`/`pack()` itself and deliberately keeps the
  older `node_id`/top-level-`score`/populated-`.snippets` shape for backward
  compatibility. Verified against a real `FileTreeKG` build: `node_id` and
  `score` were already correct.
- Checked `diary_adapter.py` and `agent_adapter.py` against their actual
  backend source (not assumed): both are correct as written.

## Test plan

- [x] `pytest -q` (593 passed)
- [x] Two new regression tests pin the metadata fix
      (`TestFTreeKGAdapterFieldMapping`), plus a `make_adapter` dispatch test
- [x] Verified live against a real `FileTreeKG` build in a scratch venv
- [x] `pre-commit run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
