### PR TITLE
fix(audit): never call an empty vector store a finished migration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -132,6 +132,30 @@
       ]
     }
   ],
-  "results": {},
-  "generated_at": "2026-06-01T14:04:06Z"
+  "results": {
+    "docs/INGESTION.md": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/INGESTION.md",
+        "hashed_secret": "cad44ce6c0d09ce4997a4eab4622b3b6b0754809",
+        "is_verified": false,
+        "line_number": 221
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/INGESTION.md",
+        "hashed_secret": "3c8aef112dd2a91e2b3c51fffc36a4868c42d66d",
+        "is_verified": false,
+        "line_number": 233
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/INGESTION.md",
+        "hashed_secret": "53d60ae7872ab82cb8e296dc84020b3611fcc10b",
+        "is_verified": false,
+        "line_number": 245
+      }
+    ]
+  },
+  "generated_at": "2026-08-25T18:33:49Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kgrag audit-lancedb` could tell you to delete a live index.** The audit
+  decided a KG had migrated to sqlite-vec by calling `Path.exists()` on its
+  `vectors.sqlite`. A failed or interrupted migration leaves a zero-table stub
+  behind, and to that check the stub is indistinguishable from a finished
+  migration -- so the KG classified as `residue` rather than `unmigrated`, and
+  `residue`'s emitted remediation is `rm -rf` of the LanceDB directory that, in
+  that state, still holds the only copy of the index. `_find_vectors()` now
+  reports a store only when its `vec_meta` table exists and carries at least
+  one row. `vec_meta` is the plain table `kg_utils.vector_backend` writes
+  alongside the `vec_nodes` `vec0` virtual table, so the check reads without
+  loading the sqlite-vec extension. Found on `waverider`'s doc KG, 2026-08-25.
+  The test fixtures could never have caught this: they built every "migrated"
+  store with `Path.touch()`, which is exactly the empty-stub shape. They now
+  write a real populated `vec_meta`, and three cases cover the stub, an
+  unreadable file, and the populated store that must still read as `residue`.
+
+### Changed
+
+- Lock moved to `kgmodule-utils` 0.18.1 and `pycode-kg` 0.24.1. Floors are
+  unchanged and deliberately so: `kgmodule-utils>=0.18.0` is a requirement
+  statement (`QueryScope.time_range` needs `kg_utils.temporal`) and nothing in
+  0.18.1 is needed. `memory-kg>=0.7.0` likewise stays put -- 0.8.0 exists in
+  that repo's CHANGELOG but was never published to PyPI, so it is not a floor
+  anything can resolve.
+- Trimmed the `kgmodule-utils` dependency comment, which had accreted a
+  paragraph per floor bump (0.13.0, 0.13.1, 0.17.0) plus merge-sequencing
+  advice that expired when 0.18.0 shipped. Git records that history; the
+  comment now states only why the current floor is what it is.
+- Regenerated `.secrets.baseline`, stale since 2026-08-15. Three SHA-256
+  checksums in `docs/INGESTION.md`'s example manifest were failing
+  `detect-secrets` on `--all-files` runs.
+
 ## [0.15.0] - 2026-08-23
 
 ### Added

--- a/poetry.lock
+++ b/poetry.lock
@@ -949,6 +949,7 @@ nvidia-cuda-cupti = {version = "==13.0.85.*", optional = true, markers = "(sys_p
 nvidia-cuda-nvrtc = {version = "==13.0.88.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and (extra == \"cublas\" or extra == \"nvrtc\")"}
 nvidia-cuda-runtime = {version = "==13.0.96.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cudart\""}
 nvidia-cufft = {version = "==12.0.0.61.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cufft\""}
+nvidia-cufile = {version = "==1.15.1.6.*", optional = true, markers = "sys_platform == \"linux\" and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cufile\""}
 nvidia-curand = {version = "==10.4.0.35.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"curand\""}
 nvidia-cusolver = {version = "==12.0.4.66.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and extra == \"cusolver\""}
 nvidia-cusparse = {version = "==12.6.3.3.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and (sys_platform == \"linux\" or platform_machine == \"x86_64\") and (platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and (extra == \"cusolver\" or extra == \"cusparse\")"}
@@ -1866,21 +1867,24 @@ referencing = ">=0.31.0"
 
 [[package]]
 name = "kgmodule-utils"
-version = "0.18.0"
+version = "0.18.1"
 description = "Shared types, graph store, semantic index, and pipeline base for the KGModule SDK"
 optional = false
 python-versions = "<3.14,>=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "kgmodule_utils-0.18.0-py3-none-any.whl", hash = "sha256:230adc9bdeb517867c18d9f357d25f619f66a64aee7fef0ee9a7cc125553a818"},
-    {file = "kgmodule_utils-0.18.0.tar.gz", hash = "sha256:b8b02d1f5397e39d1459b8f05af0ae29b218ea183ad21f2a37b533fbe75725c7"},
+    {file = "kgmodule_utils-0.18.1-py3-none-any.whl", hash = "sha256:f79c3894dbff47c25880f8d8164dcccabf06354b9142ea3ef3a6dca1dea27827"},
+    {file = "kgmodule_utils-0.18.1.tar.gz", hash = "sha256:cd6e67029d428c1085e6ad018c9d78205f6e6c9c0a46c6f747f507b78a72f4a5"},
 ]
 
 [package.dependencies]
 numpy = {version = ">=1.24.0", optional = true, markers = "extra == \"semantic\" or extra == \"viz3d\""}
 rich = {version = ">=13.0.0,<15.0.0", optional = true, markers = "extra == \"semantic\""}
 sentence-transformers = {version = ">=5.4.1", optional = true, markers = "extra == \"semantic\""}
-sqlite-vec = {version = "0.1.9", optional = true, markers = "extra == \"semantic\" or extra == \"sqlite-vec\""}
+sqlite-vec = [
+    {version = "0.1.9", optional = true, markers = "extra == \"semantic\" or extra == \"sqlite-vec\""},
+    {version = "0.1.9", optional = true, markers = "extra == \"sqlite-vec\""},
+]
 torch = {version = ">=2.5.1", optional = true, markers = "extra == \"semantic\""}
 transformers = {version = ">=5.5.0,<6", optional = true, markers = "extra == \"semantic\""}
 
@@ -1893,7 +1897,7 @@ synthesis = ["httpx (>=0.27.0)", "openai (>=1.30.0)", "pillow (>=10.0.0)"]
 synthesis-mflux = ["httpx (>=0.27.0)", "mflux (>=0.9.0)", "openai (>=1.30.0)", "pillow (>=10.0.0)"]
 viz = ["pyvis (>=0.3.2)"]
 viz3d = ["numpy (>=1.24.0)"]
-viz3d-qt = ["PyQt5 (>=5.15.0)", "numpy (>=1.24.0)", "pyvista (>=0.44.0)", "quiltwright (>=0.6.0)"]
+viz3d-qt = ["PyQt5 (>=5.15.0)", "numpy (>=1.24.0)", "pyvista (>=0.44.0)", "quiltwright (>=0.7.0)"]
 viz3d-render = ["numpy (>=1.24.0)", "pyvista (>=0.44.0)"]
 
 [[package]]
@@ -2819,6 +2823,19 @@ files = [
 nvidia-nvjitlink = "*"
 
 [[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+description = "cuFile GPUDirect libraries"
+optional = false
+python-versions = ">=3"
+groups = ["main", "dev"]
+markers = "<empty>"
+files = [
+    {file = "nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44"},
+    {file = "nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1"},
+]
+
+[[package]]
 name = "nvidia-curand"
 version = "10.4.0.35"
 description = "CURAND native runtime libraries"
@@ -3718,20 +3735,20 @@ files = [
 
 [[package]]
 name = "pycode-kg"
-version = "0.23.1"
+version = "0.24.1"
 description = "A tool to build a searchable knowledge graph from Python repositories"
 optional = false
 python-versions = "<3.14,>=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "pycode_kg-0.23.1-py3-none-any.whl", hash = "sha256:3904100f333a688aacbd1e637bf52dec9d3adaa3e79786cd8848f2203e305f1c"},
-    {file = "pycode_kg-0.23.1.tar.gz", hash = "sha256:b3896b9043d5b978239af2e7a5ecb09eb3cb8ee906b696fd8d7015050fde4926"},
+    {file = "pycode_kg-0.24.1-py3-none-any.whl", hash = "sha256:97180b04e227975bffab33d23a27e135239fa622f84df79dfac963e5afc87901"},
+    {file = "pycode_kg-0.24.1.tar.gz", hash = "sha256:cbf22c22c333756be77bf587917e06be8a48f76c4c3cbc4a2ade14576eb2ee85"},
 ]
 markers = {main = "extra == \"kg\" or extra == \"all\""}
 
 [package.dependencies]
 click = ">=8.1.0,<9"
-kgmodule-utils = {version = ">=0.13.1", extras = ["semantic", "viz3d"]}
+kgmodule-utils = {version = ">=0.18.1", extras = ["semantic", "viz3d"]}
 mcp = ">=1.0.0,<2"
 networkx = ">=3.0"
 numpy = ">=1.24.0"
@@ -3743,9 +3760,9 @@ starlette = ">=0.49.1,<1.4.0"
 torch = ">=2.5.1"
 
 [package.extras]
-all = ["PyQt5 (>=5.15.0)", "markdown (>=3.6)", "param (>=2.0.0)", "plotly (>=5.14.0)", "pyvis (>=0.3.2)", "pyvista (>=0.44.0)", "pyvistaqt (>=0.11.0)", "quiltwright (>=0.4.0)", "streamlit (>=1.56.0)", "trame-vtk (>=2.0.0)"]
+all = ["PyQt5 (>=5.15.0)", "markdown (>=3.6)", "param (>=2.0.0)", "plotly (>=5.14.0)", "pyvis (>=0.3.2)", "pyvista (>=0.44.0)", "pyvistaqt (>=0.11.0)", "quiltwright (>=0.8.0)", "streamlit (>=1.56.0)", "trame-vtk (>=2.0.0)"]
 viz = ["plotly (>=5.14.0)", "pyvis (>=0.3.2)", "streamlit (>=1.56.0)"]
-viz3d = ["PyQt5 (>=5.15.0)", "kgmodule-utils[viz3d-render] (>=0.12.1)", "markdown (>=3.6)", "param (>=2.0.0)", "pyvistaqt (>=0.11.0)", "quiltwright (>=0.4.0)", "trame-vtk (>=2.0.0)"]
+viz3d = ["PyQt5 (>=5.15.0)", "kgmodule-utils[viz3d-qt,viz3d-render] (>=0.18.1)", "markdown (>=3.6)", "param (>=2.0.0)", "pyvistaqt (>=0.11.0)", "quiltwright (>=0.8.0)", "trame-vtk (>=2.0.0)"]
 
 [[package]]
 name = "pycparser"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,24 +116,14 @@ requires-python = ">=3.12,<3.14"
 # modules, which declare their own; KGRAG only passes paths through and, in
 # `kgrag audit-lancedb`, looks for leftover directories on disk. Health checks
 # shell out to each module's CLI for the same reason (see cmd_health).
-# As of the doc-kg >=0.21.2 floor in the `kg` extra, `kgrag[kg]` no longer drags
-# lancedb in transitively either: doc-kg moved it to an opt-in `[lancedb]` extra
-# needed only to read a pre-0.20.0 store. `kgrag audit-lancedb` is unaffected --
-# it only looks for leftover directories on disk and never imports the package.
+# `kgrag[kg]` no longer drags lancedb in transitively either: doc-kg moved it
+# to an opt-in `[lancedb]` extra needed only to read a pre-0.20.0 store.
 dependencies = [
     "click>=8.1.0",
-    # 0.13.0 was the original floor because it ships TEIEmbedder, which
-    # `embed_backend = "tei"` in src/kg_rag/embed.py imports directly. 0.13.1
-    # made SnapshotManager's `repo_root` a read-only property and broke every
-    # subclass that assigns it, so nothing in the fleet may resolve to it.
-    # 0.17.0 is the floor now: `kgrag ingest` needs kg_utils.ingest, which
-    # shipped to PyPI 2026-08-18. The anydoc import inside it stays guarded
-    # regardless, so staging .md/.txt/.rst still needs no extra.
-    # 0.18.0 raises it again: QueryScope.time_range reads kg_utils.temporal,
-    # which is a core (stdlib-only) module there, so this needs no new extra.
-    # Sequencing: this floor must not merge before kgmodule-utils 0.18.0 is on
-    # PyPI, or a clean install resolves a kg_utils without `temporal` and
-    # `kg_rag.primitives` fails at import.
+    # 0.18.0 is the minimum: QueryScope.time_range reads kg_utils.temporal,
+    # a core (stdlib-only) module there, so this needs no extra. Nothing in a
+    # later release is required -- the lock tracks the newest published
+    # version, this states the minimum, and the two are not the same claim.
     "kgmodule-utils>=0.18.0",
     # Upper-bounded: mcp 2.0 removed the low-level Server decorator API
     # (`@server.list_tools()` / `@server.call_tool()`) that kg_rag.mcp_server

--- a/src/kg_rag/cli/cmd_audit.py
+++ b/src/kg_rag/cli/cmd_audit.py
@@ -13,8 +13,11 @@ of them:
 1. **Registry** — the row still records a ``lancedb_path``.
 2. **Disk** — a ``lancedb/`` directory is still present (and still costing
    space) even when nothing reads it any more.
-3. **Not yet migrated** — no ``vectors.sqlite`` exists, so LanceDB is still
-   the live index and must be converted before it can be removed.
+3. **Not yet migrated** -- no *populated* ``vectors.sqlite`` exists, so
+   LanceDB is still the live index and must be converted before it can be
+   removed.  The file being present is not the test: a failed or interrupted
+   migration leaves a zero-table stub, and counting that as migrated would
+   turn the remediation into ``rm -rf`` of the only surviving index.
 
 ``kgrag audit-lancedb`` reports all three and emits the exact remediation
 command per KG.  It never modifies anything.
@@ -30,8 +33,10 @@ Usage::
 
 from __future__ import annotations
 
+import contextlib
 import json
 import shlex
+import sqlite3
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
@@ -112,7 +117,8 @@ class LanceFinding:
     :param registry_reference: True if the registry row records a ``lancedb_path``.
     :param lancedb_dirs: LanceDB directories found on disk.
     :param reclaimable_bytes: Total size of those directories.
-    :param has_vectors: True if a sqlite-vec store exists for this KG.
+    :param has_vectors: True if a *populated* sqlite-vec store exists for
+        this KG; a present-but-empty ``vectors.sqlite`` reads as False.
     :param vectors_path: The sqlite-vec store, if one was found.
     :param fix_cmd: Suggested remediation command, or None when nothing to do.
     :param action: Short human-readable verb summarising ``fix_cmd``.
@@ -181,16 +187,56 @@ def _find_lancedb_dirs(entry: KGEntry) -> list[Path]:
     return list(seen)
 
 
+def _is_populated_vector_store(path: Path) -> bool:
+    """Report whether ``path`` is a sqlite-vec store that actually holds vectors.
+
+    Existence is not enough. A ``vectors.sqlite`` can be present and useless:
+    an interrupted or failed migration leaves a zero-table file behind, and to
+    a check that only calls :meth:`Path.exists` that stub is indistinguishable
+    from a finished migration. Treating it as finished is dangerous rather than
+    merely wrong -- it downgrades the KG from ``unmigrated`` to ``residue``,
+    and ``residue``'s remediation is ``rm -rf`` of the LanceDB directory that
+    is, in that state, still the only copy of the index.
+
+    ``vec_meta`` is the plain table :mod:`kg_utils.vector_backend` creates
+    alongside the ``vec_nodes`` ``vec0`` virtual table, one row per indexed
+    node. It is deliberately the thing checked here: being an ordinary table
+    it reads without loading the sqlite-vec extension, which the audit
+    process has no reason to have available.
+
+    :param path: Candidate ``vectors.sqlite``.
+    :return: True if the file is a readable SQLite database whose ``vec_meta``
+        table exists and carries at least one row.
+    """
+    if not path.is_file():
+        return False
+    try:
+        with contextlib.closing(sqlite3.connect(f"file:{path}?mode=ro", uri=True)) as conn:
+            row = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='vec_meta'"
+            ).fetchone()
+            if row is None:
+                return False
+            return conn.execute("SELECT EXISTS(SELECT 1 FROM vec_meta)").fetchone()[0] == 1
+    except sqlite3.Error:
+        # Unreadable, encrypted, or not a database at all: not a usable index.
+        return False
+
+
 def _find_vectors(entry: KGEntry) -> Path | None:
-    """Locate this KG's sqlite-vec store, if it has one.
+    """Locate this KG's sqlite-vec store, if it has a usable one.
+
+    A store that exists but holds no vectors is reported as absent, so the KG
+    classifies as ``unmigrated`` and is told to convert or rebuild rather than
+    to delete its LanceDB directory. See :func:`_is_populated_vector_store`.
 
     :param entry: The registry entry.
-    :return: Path to ``vectors.sqlite``, or None.
+    :return: Path to a populated ``vectors.sqlite``, or None.
     """
-    if entry.vectors_path and Path(entry.vectors_path).exists():
+    if entry.vectors_path and _is_populated_vector_store(Path(entry.vectors_path)):
         return Path(entry.vectors_path)
     default = _kg_dir(entry) / "vectors.sqlite"
-    return default if default.exists() else None
+    return default if _is_populated_vector_store(default) else None
 
 
 def _fix_for(entry: KGEntry, status: str, lancedb_dirs: list[Path]) -> tuple[str | None, str]:
@@ -355,7 +401,9 @@ def audit_lancedb(
     Reports three kinds of LanceDB residue and how to clear each:
 
     \b
-      unmigrated  LanceDB is still the live index (no vectors.sqlite).
+      unmigrated  LanceDB is still the live index (no populated
+                  vectors.sqlite -- the file may be absent, or present
+                  but empty from a failed migration).
                   Convert it — for doc-family KGs `dockg convert-index`
                   re-reads the stored vectors, so there is no re-embedding.
       residue     Already on sqlite-vec, but the lancedb/ dir is still

--- a/tests/test_cmd_audit.py
+++ b/tests/test_cmd_audit.py
@@ -10,7 +10,9 @@ classification and the remediation command emitted for each.
 
 from __future__ import annotations
 
+import contextlib
 import json
+import sqlite3
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -30,6 +32,25 @@ def _reg_opt(tmp_path: Path) -> list[str]:
     return ["--registry", str(tmp_path / "registry.sqlite")]
 
 
+def _write_vector_store(path: Path, *, populated: bool = True) -> None:
+    """Write a sqlite-vec store at ``path``.
+
+    Mirrors the shape :mod:`kg_utils.vector_backend` produces: a plain
+    ``vec_meta`` table row-aligned to a ``vec0`` virtual table. Only
+    ``vec_meta`` is created here -- it is what the audit reads, and it needs
+    no sqlite-vec extension to query.
+
+    :param path: Where to write the store.
+    :param populated: If False, create the table but insert no rows, which is
+        the shape a failed or interrupted migration leaves behind.
+    """
+    with contextlib.closing(sqlite3.connect(path)) as conn:
+        conn.execute("CREATE TABLE vec_meta(id TEXT PRIMARY KEY, kind TEXT)")
+        if populated:
+            conn.execute("INSERT INTO vec_meta(id, kind) VALUES ('n1', 'function')")
+        conn.commit()
+
+
 def _make_kg(
     tmp_path: Path,
     name: str,
@@ -40,11 +61,17 @@ def _make_kg(
     vectors_on_disk: bool = False,
     record_lancedb: bool = False,
     lancedb_bytes: int = 0,
+    vectors_populated: bool = True,
 ) -> KGEntry:
     """Build a repo layout and a matching KGEntry.
 
     ``record_lancedb`` controls the *registry* reference independently of
     whether the directory exists, so stale rows can be modelled.
+
+    ``vectors_on_disk`` writes a real sqlite-vec store -- a ``vec_meta``
+    table carrying one row -- because that is what the audit now checks.
+    Set ``vectors_populated=False`` to get the failed-migration shape
+    instead: the file exists and is a valid database, but holds no vectors.
     """
     repo = tmp_path / name
     kg_dir = repo / marker
@@ -58,7 +85,7 @@ def _make_kg(
         lancedb.mkdir(exist_ok=True)
         (lancedb / "data.lance").write_bytes(b"x" * lancedb_bytes)
     if vectors_on_disk:
-        (kg_dir / "vectors.sqlite").touch()
+        _write_vector_store(kg_dir / "vectors.sqlite", populated=vectors_populated)
 
     return KGEntry(
         name=name,
@@ -94,6 +121,46 @@ class TestAuditClassification:
         f = audit_entry(entry)
         assert f.status == "residue"
         assert f.has_vectors is True
+
+    def test_empty_vector_store_is_unmigrated_not_residue(self, tmp_path):
+        """A failed migration must never be told to delete its LanceDB dir.
+
+        The regression this guards: ``vectors.sqlite`` was probed with
+        :meth:`Path.exists`, so a zero-row stub counted as a finished
+        migration. The KG then classified as ``residue``, whose remediation
+        is ``rm -rf`` of the LanceDB directory -- which in this state holds
+        the only copy of the index. Found on ``waverider``'s doc KG,
+        2026-08-25.
+        """
+        entry = _make_kg(
+            tmp_path,
+            "stub",
+            lancedb_on_disk=True,
+            vectors_on_disk=True,
+            vectors_populated=False,
+        )
+        f = audit_entry(entry)
+
+        assert f.status == "unmigrated"
+        assert f.has_vectors is False
+        assert "rm -rf" not in (f.fix_cmd or "")
+
+    def test_unreadable_vector_store_is_not_counted_as_migrated(self, tmp_path):
+        entry = _make_kg(tmp_path, "junk", lancedb_on_disk=True)
+        (tmp_path / "junk" / ".pycodekg" / "vectors.sqlite").write_bytes(b"not a database")
+        f = audit_entry(entry)
+
+        assert f.status == "unmigrated"
+        assert f.has_vectors is False
+
+    def test_populated_vector_store_still_reads_as_migrated(self, tmp_path):
+        """The fix must not swing the other way and call real stores empty."""
+        entry = _make_kg(tmp_path, "real", lancedb_on_disk=True, vectors_on_disk=True)
+        f = audit_entry(entry)
+
+        assert f.status == "residue"
+        assert f.has_vectors is True
+        assert f.fix_cmd.startswith("rm -rf")
 
     def test_stale_row_when_registry_points_at_missing_dir(self, tmp_path):
         entry = _make_kg(tmp_path, "c", vectors_on_disk=True, record_lancedb=True)


### PR DESCRIPTION
## The bug

`kgrag audit-lancedb` decided whether a KG had migrated to sqlite-vec by
calling `Path.exists()` on its `vectors.sqlite`. A failed or interrupted
migration leaves a **zero-table stub** behind, and to that check the stub is
indistinguishable from a finished migration.

That is not a cosmetic misreport. The KG classifies as `residue` instead of
`unmigrated`, and `residue`'s emitted remediation is:

```
rm -rf <repo>/.dockg/lancedb
```

which in that state is **still the only copy of the index**. The audit's
documented `kgrag audit-lancedb --commands | sh` path would have destroyed it.

Found on `waverider`'s doc KG during fleet housekeeping on 2026-08-25: a
4096-byte `vectors.sqlite` with zero tables, sitting beside 4.6 MB of LanceDB
that the audit was recommending for deletion.

## The fix

`_find_vectors()` now reports a store only when its `vec_meta` table exists and
carries at least one row.

`vec_meta` is the plain table `kg_utils.vector_backend` writes alongside the
`vec_nodes` `vec0` virtual table, one row per indexed node. It is deliberately
the thing checked: being an ordinary table it reads without loading the
sqlite-vec extension, which the audit process has no reason to have available.
`vec_nodes` itself cannot be queried without it (`no such module: vec0`).

Unreadable files and non-databases are treated the same way. A KG in any of
these states classifies as `unmigrated` and is told to convert or rebuild,
which is correct and safe.

## Why the tests missed it

Every "migrated" store in the suite was built with `Path.touch()` -- precisely
the empty-stub shape the bug turns on. The fixtures asserted that the buggy
behaviour was correct, so no amount of running them would have surfaced this.

`_write_vector_store()` now writes a real populated `vec_meta`. Three cases
were added:

| case | expected |
|---|---|
| stub `vectors.sqlite` + lancedb | `unmigrated`, and **no `rm -rf`** in the fix command |
| unreadable/non-database file | `unmigrated` |
| populated store + lancedb | still `residue` with `rm -rf` -- the fix must not swing the other way |

## Dependencies (second commit)

The lock was testing against `kgmodule-utils` 0.18.0 and `pycode-kg` 0.23.1
while the fleet ships 0.18.1 and 0.24.1. Relocked to both.

**Floors are deliberately unchanged.** `kgmodule-utils>=0.18.0` is a
requirement statement, not a currency marker -- it is where `kg_utils.temporal`
landed, which `QueryScope.time_range` reads, and nothing in 0.18.1 is needed
here. `memory-kg>=0.7.0` stays because 0.8.0 exists in that repo's CHANGELOG
but was never uploaded to PyPI, so it is not a floor anything can resolve.
(`fleet_audit.py` reports that one as consumer drift because it compares
against versions *built* in the fleet rather than published ones. Noise, not a
stale pin.)

The `kgmodule-utils` comment had accreted a paragraph per floor bump --
0.13.0's TEIEmbedder, 0.13.1's `repo_root` regression, 0.17.0's
`kg_utils.ingest` -- none reachable under the current constraint, plus
merge-sequencing advice that expired when 0.18.0 shipped on 2026-08-18. Git
records that history. The `mcp<2` and `[jupyter]` comments are left alone;
both explain live decisions.

Also regenerates `.secrets.baseline`, stale since 2026-08-15 -- three SHA-256
checksums in `docs/INGESTION.md`'s example manifest were failing
`detect-secrets` on `--all-files`. Pre-existing and unrelated, but it blocked
the pre-commit gate.

## Verification

- 890 tests pass (27 in `test_cmd_audit.py`, up from 24).
- All 12 pre-commit hooks green against a synced environment on
  kgmodule-utils 0.18.1 / pycode-kg 0.24.1.
- Re-ran the audit against the live 394-KG registry: all 12 `residue` KGs
  re-verified against a real populated `vec_meta` before any deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
