### PR TITLE
fix(cli): stop implying an undated module is an unfinished one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`kgrag timeline` no longer implies that an undated module is unfinished.**
+  The line read *"their module does not write the temporal contract"*, which
+  frames being undated as a gap. It usually is not: code KGs answer "how did
+  this change" with snapshots and git already owns their dates, and a metabolic
+  pathway does not occur at a time — its `t=0..100` is an integration axis.
+  Those modules are correctly abstaining, and the old wording made a settled
+  design decision read as a defect.
+
+  The count now names which KGs the undated hits came from and says plainly
+  that not every KG is dated.
+
+
 ### Fixed
 
 - **`kgrag audit-lancedb` could tell you to delete a live index.** The audit

--- a/src/kg_rag/cli/cmd_timeline.py
+++ b/src/kg_rag/cli/cmd_timeline.py
@@ -104,9 +104,11 @@ def timeline(query_text, date_from, date_to, k, kind, output_json, min_score, re
         kgrag timeline "manifold work" --from 2026-04
         kgrag timeline "photographs" --from 1998 --kind filetree
 
-    Hits that carry no date at all are counted and reported, never silently
-    dropped — a module that has not adopted the temporal contract would
-    otherwise look like a module with nothing to say.
+    Hits that carry no date are counted and named, never silently dropped.
+    Being undated is often correct rather than missing: code KGs track change
+    through snapshots and git already owns their dates, and a metabolic pathway
+    does not occur at a time. The count exists so those results stay visible,
+    not to mark a module as unfinished.
     """
     scope = QueryScope(time_range=(date_from, date_to)) if (date_from or date_to) else None
 
@@ -191,7 +193,14 @@ def timeline(query_text, date_from, date_to, k, kind, output_json, min_score, re
         console.print(table)
 
     if undated:
+        # Deliberately neutral. Some modules carry no dates *by design* -- code
+        # KGs answer "how did this change" with snapshots and git already owns
+        # their dates, and MetaboKG's only clock is an ODE integration axis.
+        # Wording that implied a missing feature read as a defect in modules
+        # that are correctly abstaining.
+        kgs = ", ".join(sorted({h.kg_name for h in undated}))
         console.print(
-            f"[dim]{len(undated)} undated hit(s) not shown — "
-            f"their module does not write the temporal contract.[/dim]"
+            f"[dim]{len(undated)} hit(s) carry no date and are not placed on the "
+            f"timeline ({kgs}). Not every KG is dated — code and pathway graphs "
+            f"track change through snapshots instead.[/dim]"
         )


### PR DESCRIPTION
## What

A one-line consequence of a design decision taken after `kgrag timeline` shipped.

The footer read:

```
842 undated hit(s) not shown — their module does not write the temporal contract.
```

That frames being undated as a gap waiting to be closed. It usually is not.

## Why the framing was wrong

`FLEET_STANDARDS.md` now records *"Which modules should not adopt"*, and the reasoning is specific:

- **Code KGs** carry no calendar time on their nodes, and answer "how did this change" with snapshots. More decisively, **git already owns their dates** — copying commit dates into node metadata would be a second authoring that goes stale on the very next commit, exactly the drift *derive, don't author twice* forbids.
- **MetaboKG's** only clock is an ODE integration axis. Mapping `t=0..100` onto `occurred_start` would put every pathway in 1970.

Those modules are correctly abstaining. The old wording made a settled decision read as a defect to whoever ran the command — and it would have read that way permanently, since nothing is ever going to "fix" it.

## What it says now

```
842 hit(s) carry no date and are not placed on the timeline (pycodekg, metabokg).
Not every KG is dated — code and pathway graphs track change through snapshots instead.
```

Naming the KGs is more useful anyway: it tells you *which* results you're not seeing.

The command's docstring carried the same implication and is corrected to match.

## Testing

890 passed, ruff clean. No behaviour change — the undated hits were already counted and excluded; only the explanation changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQCX2jvtYjTs3Naqn4ZcUr)_